### PR TITLE
fix: prevent model search crash on incomplete model metadata

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -57,10 +57,10 @@ export async function getActiveModels(directory?: string): Promise<ModelInfo[]> 
         
         models.push({
           id: model.id,
-          name: model.name,
+          name: model.name || model.id,
           providerId: provider.id,
-          providerName: provider.name,
-          family: model.family,
+          providerName: provider.name || provider.id,
+          family: model.family || '',
           contextLimit: model.limit.context,
           outputLimit: model.limit.output,
           supportsReasoning: model.capabilities.reasoning,

--- a/src/features/chat/ModelSelector.tsx
+++ b/src/features/chat/ModelSelector.tsx
@@ -53,11 +53,13 @@ export const ModelSelector = memo(forwardRef<ModelSelectorHandle, ModelSelectorP
   const filteredModels = useMemo(() => {
     if (!searchQuery.trim()) return models
     const query = searchQuery.toLowerCase()
+    const normalize = (value: unknown) => (typeof value === 'string' ? value : '').toLowerCase()
+
     return models.filter(m =>
-      m.name.toLowerCase().includes(query) ||
-      m.id.toLowerCase().includes(query) ||
-      m.family.toLowerCase().includes(query) ||
-      m.providerName.toLowerCase().includes(query)
+      normalize(m.name).includes(query) ||
+      normalize(m.id).includes(query) ||
+      normalize(m.family).includes(query) ||
+      normalize(m.providerName).includes(query)
     )
   }, [models, searchQuery])
 


### PR DESCRIPTION
## 问题
- 在模型选择器 `Search models...` 输入时，某些模型字段缺失会触发 `Cannot read properties of undefined (reading 'toLowerCase')`，导致页面崩溃。

## 修复
- 在模型搜索过滤逻辑中增加字符串归一化兜底，避免对 `undefined` 直接调用 `toLowerCase()`。
- 在模型数据映射阶段补齐关键字段默认值：
  - `name` 缺失时回退到 `model.id`
  - `providerName` 缺失时回退到 `provider.id`
  - `family` 缺失时回退为空字符串

## 影响
- 模型元数据不完整时，搜索仍可正常工作，不再触发全局崩溃。
- 对正常完整数据无行为变化。

## 验证
- 本地测试通过