### PR TITLE
fix: show all non-subagent agents in selector to match official WebUI

### DIFF
--- a/src/features/chat/input/InputToolbar.tsx
+++ b/src/features/chat/input/InputToolbar.tsx
@@ -110,7 +110,7 @@ export function InputToolbar({
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
   
-  const selectableAgents = agents.filter(a => a.mode === 'primary' && !a.hidden)
+  const selectableAgents = agents.filter(a => a.mode !== 'subagent' && !a.hidden)
   const currentAgent = agents.find(a => a.name === selectedAgent)
 
   return (

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -246,7 +246,7 @@ export function useChatSession({ chatAreaRef, currentModel, refetchModels }: Use
   // agents 列表加载后，校验当前选中的 agent 是否存在于列表中
   useEffect(() => {
     if (agents.length === 0) return
-    const primaryAgents = agents.filter(a => a.mode === 'primary' && !a.hidden)
+    const primaryAgents = agents.filter(a => a.mode !== 'subagent' && !a.hidden)
     if (primaryAgents.length === 0) return
 
     // 当前选中的 agent 在列表中存在就不动
@@ -478,7 +478,7 @@ export function useChatSession({ chatAreaRef, currentModel, refetchModels }: Use
 
   // Toggle agent (cycle through primary agents only, matching toolbar display)
   const handleToggleAgent = useCallback(() => {
-    const primaryAgents = agents.filter(a => a.mode === 'primary' && !a.hidden)
+    const primaryAgents = agents.filter(a => a.mode !== 'subagent' && !a.hidden)
     if (primaryAgents.length <= 1) return
     const currentIndex = primaryAgents.findIndex(a => a.name === selectedAgent)
     const nextIndex = (currentIndex + 1) % primaryAgents.length
@@ -489,7 +489,7 @@ export function useChatSession({ chatAreaRef, currentModel, refetchModels }: Use
   const restoreAgentFromMessage = useCallback((agentName: string | null | undefined) => {
     if (!agentName) return
     // 只有当 agent 存在于列表中时才恢复
-    const exists = agents.some(a => a.name === agentName && a.mode === 'primary' && !a.hidden)
+    const exists = agents.some(a => a.name === agentName && a.mode !== 'subagent' && !a.hidden)
     if (exists) {
       setSelectedAgent(agentName)
     }


### PR DESCRIPTION
## 问题

在启用 oh-my-opencode 等自定义 agent 配置时，部分 agent（如 Prometheus Plan Builder）
无法出现在 agent 选择下拉框中。

## 根因

原过滤逻辑为白名单式：

```ts
agents.filter(a => a.mode === 'primary' && !a.hidden)
```

而官方 opencode WebUI 使用的是黑名单式过滤：

```ts
agents.filter(a => a.mode !== 'subagent' && !a.hidden)
```

根据 opencode 的 schema，`mode` 字段默认值为 `"all"`（未显式设置时）。
使用 `=== 'primary'` 会错误排除 `mode: "all"` 的 agent，导致它们从列表中消失。

## 修复

将 `InputToolbar.tsx` 和 `useChatSession.ts` 中共 4 处过滤条件统一改为
`mode !== 'subagent'`，与官方行为对齐。

## 修复前后对比

修复前：

<img width="303" height="216" alt="PixPin_2026-02-19_21-32-55" src="https://github.com/user-attachments/assets/a7e81613-8bbc-46b2-a3af-26d803f19a5e" />

修复后：

<img width="312" height="294" alt="PixPin_2026-02-19_21-32-48" src="https://github.com/user-attachments/assets/3c9b1c6b-e884-4698-9982-b37d40879c0e" />

