### PR TITLE
[Fix] guard session error without sessionID

### DIFF
--- a/src/hooks/useGlobalEvents.ts
+++ b/src/hooks/useGlobalEvents.ts
@@ -342,6 +342,9 @@ export function useGlobalEvents(directories?: string[]) {
         if (!isAbort && import.meta.env.DEV) {
           console.warn('[GlobalEvents] Session error:', error)
         }
+        if (error.sessionID == null || error.sessionID.length < 1) {
+          return // Don't handle errors with no sessionID
+        }
         messageStore.handleSessionError(error.sessionID)
         childSessionStore.markError(error.sessionID)
         if (!isAbort) {


### PR DESCRIPTION
This pr prevents session error handling from running when the backend error payload does not include a valid sessionID, avoiding follow-up failures during global event processing.

## New Features

None.

## Bug fixes

See the list of fixed issues below
- Guard session error handling when `sessionID` is missing or empty in `useGlobalEvents`
- Prevent invalid session error events from propagating into message/session stores

## Other Changes

None.