### PR TITLE
feat: resolve issue #74 running tool durations

### DIFF
--- a/src/api/events.test.ts
+++ b/src/api/events.test.ts
@@ -67,6 +67,20 @@ function createFetchResponse(chunks: Uint8Array[]): Pick<Response, 'ok' | 'body'
   }
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function createEventChunk(payload: object): Uint8Array[] {
+  return [encoder.encode(`data: ${JSON.stringify({ directory: 'global', payload })}\n\n`)]
+}
+
 describe('subscribeToEvents', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -119,5 +133,85 @@ describe('subscribeToEvents', () => {
     })
 
     expect(received).toBe('𠮷😀')
+  })
+
+  it('dispatches server.connected payloads with timestamp', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      createFetchResponse(
+        createEventChunk({
+          type: EventTypes.SERVER_CONNECTED,
+          properties: { timestamp: '2026-04-22T15:00:00.000Z' },
+        }),
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { subscribeToEvents } = await import('./events')
+
+    const received = await new Promise<unknown>((resolve, reject) => {
+      const unsubscribe = subscribeToEvents({
+        onServerConnected(data) {
+          unsubscribe()
+          resolve(data.timestamp)
+        },
+        onError(error) {
+          unsubscribe()
+          reject(error)
+        },
+      })
+    })
+
+    expect(received).toBe('2026-04-22T15:00:00.000Z')
+  })
+
+  it('ignores stale server.connected events from an old browser SSE generation after reconnect', async () => {
+    const firstFetch = createDeferred<Pick<Response, 'ok' | 'body'>>()
+    const secondFetch = createDeferred<Pick<Response, 'ok' | 'body'>>()
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => firstFetch.promise)
+      .mockImplementationOnce(() => secondFetch.promise)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { subscribeToEvents, reconnectSSE } = await import('./events')
+    const received: string[] = []
+
+    const unsubscribe = subscribeToEvents({
+      onServerConnected(data) {
+        if (typeof data.timestamp === 'string') {
+          received.push(data.timestamp)
+        }
+      },
+    })
+
+    reconnectSSE()
+
+    secondFetch.resolve(
+      createFetchResponse(
+        createEventChunk({
+          type: EventTypes.SERVER_CONNECTED,
+          properties: { timestamp: 'new-server-time' },
+        }),
+      ),
+    )
+
+    await vi.waitFor(() => {
+      expect(received).toEqual(['new-server-time'])
+    })
+
+    firstFetch.resolve(
+      createFetchResponse(
+        createEventChunk({
+          type: EventTypes.SERVER_CONNECTED,
+          properties: { timestamp: 'stale-server-time' },
+        }),
+      ),
+    )
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(received).toEqual(['new-server-time'])
+    unsubscribe()
   })
 })

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -6,7 +6,14 @@ import { getApiBaseUrl, getAuthHeader } from './http'
 import { createSseTextParser } from './sse'
 import { normalizeTodoItems } from './todo'
 import { isTauri } from '../utils/tauri'
-import type { EventCallbacks, EventType, GlobalEvent, SessionErrorPayload, TodoUpdatedPayload } from './types'
+import type {
+  EventCallbacks,
+  EventType,
+  GlobalEvent,
+  ServerConnectedPayload,
+  SessionErrorPayload,
+  TodoUpdatedPayload,
+} from './types'
 import { EventTypes } from '../types/api/event'
 
 // ============================================
@@ -33,7 +40,9 @@ const connectionListeners = new Set<(info: ConnectionInfo) => void>()
 
 function updateConnectionState(update: Partial<ConnectionInfo>) {
   connectionInfo = { ...connectionInfo, ...update }
-  connectionListeners.forEach(fn => fn(connectionInfo))
+  connectionListeners.forEach(fn => {
+    fn(connectionInfo)
+  })
 }
 
 export function getConnectionInfo(): ConnectionInfo {
@@ -96,7 +105,9 @@ function broadcastReconnected(reason: 'network' | 'server-switch') {
     return
   }
   lastReconnectedBroadcast = now
-  allSubscribers.forEach(cb => cb.onReconnected?.(reason))
+  allSubscribers.forEach(cb => {
+    cb.onReconnected?.(reason)
+  })
 }
 
 /**
@@ -282,7 +293,9 @@ async function connectViaTauri() {
             state: 'error',
             error: errorMsg,
           })
-          allSubscribers.forEach(cb => cb.onError?.(new Error(errorMsg)))
+          allSubscribers.forEach(cb => {
+            cb.onError?.(new Error(errorMsg))
+          })
           scheduleReconnect()
           break
         }
@@ -303,7 +316,9 @@ async function connectViaTauri() {
         state: 'error',
         error: errorMsg,
       })
-      allSubscribers.forEach(cb => cb.onError?.(new Error(errorMsg)))
+      allSubscribers.forEach(cb => {
+        cb.onError?.(new Error(errorMsg))
+      })
       scheduleReconnect()
     })
   } catch (error) {
@@ -334,6 +349,11 @@ function connectViaBrowser() {
   })
     .then(async response => {
       isConnecting = false
+
+      if (myGeneration !== connectionGeneration) {
+        await response.body?.cancel?.().catch(() => {})
+        return
+      }
 
       if (!response.ok) {
         throw new Error(`Failed to subscribe: ${response.status}`)
@@ -371,6 +391,11 @@ function connectViaBrowser() {
         }
 
         const { done, value } = await reader.read()
+        if (myGeneration !== connectionGeneration) {
+          reader.cancel().catch(() => {})
+          break
+        }
+
         if (done) {
           if (import.meta.env.DEV) {
             console.log('[SSE] Stream ended, reconnecting...')
@@ -405,7 +430,9 @@ function connectViaBrowser() {
         error: error.message || 'Connection failed',
       })
       // 通知所有订阅者出错
-      allSubscribers.forEach(cb => cb.onError?.(error))
+      allSubscribers.forEach(cb => {
+        cb.onError?.(error)
+      })
       scheduleReconnect()
     })
 }
@@ -718,9 +745,19 @@ function handleEventForSubscriber(payload: GlobalEvent['payload'], callbacks: Ev
       } satisfies TodoUpdatedPayload)
       break
     }
+    case EventTypes.SERVER_CONNECTED:
+      callbacks.onServerConnected?.(normalizeServerConnected(payload.properties))
+      break
     default:
       // 忽略其他事件类型
       break
+  }
+}
+
+function normalizeServerConnected(properties: unknown): ServerConnectedPayload {
+  if (!isRecord(properties)) return {}
+  return {
+    timestamp: properties.timestamp,
   }
 }
 

--- a/src/features/chat/RetryStatusInline.tsx
+++ b/src/features/chat/RetryStatusInline.tsx
@@ -1,7 +1,8 @@
-import { memo, useEffect, useMemo, useState } from 'react'
+import { memo, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ChevronDownIcon, RetryIcon } from '../../components/Icons'
 import { useDelayedRender } from '../../hooks/useDelayedRender'
+import { useNow } from '../../hooks/useNow'
 
 export interface RetryStatusInlineData {
   sessionID: string
@@ -20,7 +21,7 @@ function formatRemaining(ms: number): string {
 
 export const RetryStatusInline = memo(function RetryStatusInline({ status }: { status: RetryStatusInlineData }) {
   const { t } = useTranslation('chat')
-  const [now, setNow] = useState(() => Date.now())
+  const now = useNow(250)
   const [expanded, setExpanded] = useState(false)
   const shouldRenderBody = useDelayedRender(expanded)
 
@@ -32,37 +33,40 @@ export const RetryStatusInline = memo(function RetryStatusInline({ status }: { s
   const nextLabel = remainingMs !== null && remainingMs > 0 ? formatRemaining(remainingMs) : null
   const hasMessage = Boolean(status.message?.trim())
 
-  // Tick the countdown timer while visible
-  useEffect(() => {
-    const timer = window.setInterval(() => setNow(Date.now()), 250)
-    return () => window.clearInterval(timer)
-  }, [])
-
   return (
-    <div
-      className="my-2 px-3 py-2 rounded-lg border border-warning-100/20 bg-warning-100/10"
-      role="status"
-      aria-live="polite"
-    >
-      <div
-        className={`flex items-center gap-2 min-w-0 ${hasMessage ? 'cursor-pointer' : ''}`}
-        onClick={() => hasMessage && setExpanded(prev => !prev)}
-      >
-        <RetryIcon className="w-4 h-4 text-warning-100 flex-shrink-0" />
-        <span className="text-[length:var(--fs-base)] text-warning-100 flex-1 min-w-0 truncate">
-          {t('retryStatus.retrying', { attempt: status.attempt })}
-          {nextLabel && (
-            <span className="text-[length:var(--fs-sm)] text-text-400 ml-2 tabular-nums">
-              {t('retryStatus.nextIn', { label: nextLabel })}
-            </span>
-          )}
-        </span>
-        {hasMessage && (
+    <div className="my-2 px-3 py-2 rounded-lg border border-warning-100/20 bg-warning-100/10">
+      {hasMessage ? (
+        <button
+          type="button"
+          className="flex w-full items-center gap-2 min-w-0 text-left cursor-pointer"
+          onClick={() => setExpanded(prev => !prev)}
+        >
+          <RetryIcon className="w-4 h-4 text-warning-100 flex-shrink-0" />
+          <span className="text-[length:var(--fs-base)] text-warning-100 flex-1 min-w-0 truncate">
+            {t('retryStatus.retrying', { attempt: status.attempt })}
+            {nextLabel && (
+              <span className="text-[length:var(--fs-sm)] text-text-400 ml-2 tabular-nums">
+                {t('retryStatus.nextIn', { label: nextLabel })}
+              </span>
+            )}
+          </span>
           <ChevronDownIcon
             className={`w-4 h-4 text-text-400 transition-transform duration-300 ${expanded ? '' : '-rotate-90'}`}
           />
-        )}
-      </div>
+        </button>
+      ) : (
+        <div className="flex items-center gap-2 min-w-0">
+          <RetryIcon className="w-4 h-4 text-warning-100 flex-shrink-0" />
+          <span className="text-[length:var(--fs-base)] text-warning-100 flex-1 min-w-0 truncate">
+            {t('retryStatus.retrying', { attempt: status.attempt })}
+            {nextLabel && (
+              <span className="text-[length:var(--fs-sm)] text-text-400 ml-2 tabular-nums">
+                {t('retryStatus.nextIn', { label: nextLabel })}
+              </span>
+            )}
+          </span>
+        </div>
+      )}
 
       {hasMessage && (
         <div

--- a/src/features/message/parts/ToolPartView.test.tsx
+++ b/src/features/message/parts/ToolPartView.test.tsx
@@ -1,0 +1,126 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ToolPartView } from './ToolPartView'
+import type { ToolPart } from '../../../types/message'
+
+const { getActiveCalibratedNowMock } = vi.hoisted(() => ({
+  getActiveCalibratedNowMock: vi.fn<() => number | undefined>(() => undefined),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      if (key === 'toolPart.running') return 'Running'
+      if (key === 'toolPart.failed') return 'Failed'
+      return key
+    },
+  }),
+}))
+
+vi.mock('../../../hooks', () => ({
+  useDelayedRender: (show: boolean) => show,
+}))
+
+vi.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({
+    inlineToolRequests: false,
+    immersiveMode: false,
+    compactInlinePermission: false,
+  }),
+}))
+
+vi.mock('../../../store/serverStore', () => ({
+  serverStore: {
+    getActiveCalibratedNow: getActiveCalibratedNowMock,
+  },
+}))
+
+vi.mock('../../chat/InlineToolRequestContext', () => ({
+  useInlineToolRequests: () => ({
+    pendingPermissions: [],
+    pendingQuestions: [],
+    onPermissionReply: vi.fn(),
+    onQuestionReply: vi.fn(),
+    onQuestionReject: vi.fn(),
+    isReplying: false,
+  }),
+  findPermissionRequestForTool: () => undefined,
+  findQuestionRequestForTool: () => undefined,
+}))
+
+vi.mock('../../chat/InlinePermission', () => ({
+  InlinePermission: () => null,
+}))
+
+vi.mock('../../chat/InlineQuestion', () => ({
+  InlineQuestion: () => null,
+}))
+
+vi.mock('../tools', () => ({
+  getToolIcon: () => <span data-testid="tool-icon">icon</span>,
+  extractToolData: () => ({}),
+  getToolConfig: () => undefined,
+  DefaultRenderer: () => null,
+  TodoRenderer: () => null,
+  TaskRenderer: () => null,
+  hasTodos: () => false,
+}))
+
+function createRunningToolPart(): ToolPart {
+  return {
+    id: 'tool-1',
+    sessionID: 'session-1',
+    messageID: 'message-1',
+    type: 'tool',
+    callID: 'call-1',
+    tool: 'bash',
+    state: {
+      status: 'running',
+      title: 'npm run build',
+      time: { start: 7_500 },
+    },
+  }
+}
+
+describe('ToolPartView running duration', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(10_000)
+    getActiveCalibratedNowMock.mockReset()
+    getActiveCalibratedNowMock.mockReturnValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('falls back to local wall clock when calibration is unavailable', () => {
+    render(<ToolPartView part={createRunningToolPart()} />)
+
+    expect(screen.getByText('Running')).toBeInTheDocument()
+    expect(screen.getByText('2.5s')).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(screen.getByText('3.0s')).toBeInTheDocument()
+  })
+
+  it('uses calibrated server time for running tools when available', () => {
+    getActiveCalibratedNowMock.mockReturnValue(11_000)
+
+    render(<ToolPartView part={createRunningToolPart()} />)
+
+    expect(screen.getByText('3.5s')).toBeInTheDocument()
+  })
+
+  it('clamps running duration to zero when calibrated time is earlier than start', () => {
+    getActiveCalibratedNowMock.mockReturnValue(7_000)
+
+    render(<ToolPartView part={createRunningToolPart()} />)
+
+    expect(screen.getByText('0ms')).toBeInTheDocument()
+  })
+})

--- a/src/features/message/parts/ToolPartView.tsx
+++ b/src/features/message/parts/ToolPartView.tsx
@@ -4,6 +4,8 @@ import { diffLines } from 'diff'
 import { ChevronDownIcon, ChevronRightIcon } from '../../../components/Icons'
 import type { ToolPart } from '../../../types/message'
 import { useDelayedRender } from '../../../hooks'
+import { useNow } from '../../../hooks/useNow'
+import { serverStore } from '../../../store/serverStore'
 import { useTheme } from '../../../hooks/useTheme'
 import { formatToolName, formatDuration } from '../../../utils/formatUtils'
 import {
@@ -52,10 +54,14 @@ export const ToolPartView = memo(function ToolPartView({
   const { state, tool: toolName } = part
   const title = state.title || getInputDescription(part) || ''
 
-  const duration = state.time?.start && state.time?.end ? state.time.end - state.time.start : undefined
-
   const isActive = state.status === 'running' || state.status === 'pending'
   const isError = state.status === 'error'
+  const now = useNow(250, isActive)
+  const startTime = state.time?.start
+  const calibratedNow = isActive ? serverStore.getActiveCalibratedNow() : undefined
+  const endTime = state.time?.end ?? (isActive ? (calibratedNow ?? now) : undefined)
+  const rawDuration = startTime !== undefined && endTime !== undefined ? endTime - startTime : undefined
+  const duration = rawDuration !== undefined && isActive ? Math.max(0, rawDuration) : rawDuration
   const { inlineToolRequests, immersiveMode, compactInlinePermission } = useTheme()
 
   const { pendingPermissions, pendingQuestions, onPermissionReply, onQuestionReply, onQuestionReject, isReplying } =
@@ -131,17 +137,11 @@ export const ToolPartView = memo(function ToolPartView({
     <div
       className={`
       relative flex items-center justify-center transition-colors duration-200
-      ${isActive ? 'text-accent-main-100' : ''}
+      ${isActive ? 'text-text-300' : ''}
       ${isError ? 'text-danger-100' : ''}
       ${state.status === 'completed' ? 'text-text-400 group-hover:text-text-300' : ''}
     `}
     >
-      {isActive && (
-        <span
-          className="absolute inset-0 rounded-full bg-accent-main-100/20 animate-ping"
-          style={{ animationDuration: '1.5s' }}
-        />
-      )}
       {getToolIcon(toolName)}
     </div>
   )
@@ -224,9 +224,9 @@ export const ToolPartView = memo(function ToolPartView({
           </div>
 
           <div className="ml-auto flex shrink-0 items-center gap-2">
-            {duration !== undefined && state.status === 'completed' && (
+            {duration !== undefined && (state.status === 'completed' || isActive) && (
               <span
-                className={`text-[length:var(--fs-xxs)] font-mono tabular-nums ${isError ? 'text-danger-100/70' : 'text-text-500'}`}
+                className={`text-[length:var(--fs-xxs)] font-mono tabular-nums ${isError ? 'text-danger-100/70' : isActive ? 'reasoning-shimmer-text' : 'text-text-500'}`}
               >
                 {formatDuration(duration)}
               </span>
@@ -256,6 +256,7 @@ export const ToolPartView = memo(function ToolPartView({
         {/* Content column */}
         <div className="min-w-0">
           <button
+            type="button"
             className="flex items-center gap-2 w-full h-9 text-left pl-2 pr-0 hover:bg-bg-200/40 rounded-sm transition-colors group/header"
             onClick={() => setExpanded(!expanded)}
           >
@@ -263,7 +264,7 @@ export const ToolPartView = memo(function ToolPartView({
               <span
                 className={`font-medium text-[length:var(--fs-md)] leading-tight transition-colors duration-300 shrink-0 ${
                   isActive
-                    ? 'text-accent-main-100'
+                    ? 'reasoning-shimmer-text'
                     : isError
                       ? 'text-danger-100'
                       : 'text-text-200 group-hover/header:text-text-100'
@@ -272,20 +273,28 @@ export const ToolPartView = memo(function ToolPartView({
                 {formatToolName(toolName)}
               </span>
               {title && (
-                <span className="text-[length:var(--fs-sm)] text-text-400 truncate min-w-0 flex-1 font-mono opacity-70">
+                <span
+                  className={`text-[length:var(--fs-sm)] truncate min-w-0 flex-1 font-mono ${
+                    isActive ? 'reasoning-shimmer-text' : 'text-text-400 opacity-70'
+                  }`}
+                >
                   {title}
                 </span>
               )}
             </div>
             <div className="flex items-center gap-2 ml-auto shrink-0">
-              {duration !== undefined && state.status === 'completed' && (
-                <span className="text-[length:var(--fs-xxs)] font-mono text-text-500 tabular-nums">
+              {duration !== undefined && (state.status === 'completed' || isActive) && (
+                <span
+                  className={`text-[length:var(--fs-xxs)] font-mono tabular-nums ${
+                    isActive ? 'reasoning-shimmer-text' : 'text-text-500'
+                  }`}
+                >
                   {formatDuration(duration)}
                 </span>
               )}
               <span
                 className={`text-[length:var(--fs-xxs)] font-medium transition-all duration-300 ${
-                  isActive ? 'opacity-100 text-accent-main-100' : 'opacity-0 w-0 overflow-hidden'
+                  isActive ? 'opacity-100 text-text-400' : 'opacity-0 w-0 overflow-hidden'
                 }`}
               >
                 {t('toolPart.running')}
@@ -337,6 +346,7 @@ export const ToolPartView = memo(function ToolPartView({
       <div className="flex-1 min-w-0">
         {/* Header - h-9 和 timeline 图标行等高 */}
         <button
+          type="button"
           className="flex items-center gap-2.5 w-full h-9 text-left pl-2 pr-0 hover:bg-bg-200/40 rounded-sm transition-colors group/header"
           onClick={() => setExpanded(!expanded)}
         >
@@ -344,7 +354,7 @@ export const ToolPartView = memo(function ToolPartView({
             <span
               className={`font-medium text-[length:var(--fs-md)] leading-tight transition-colors duration-300 shrink-0 ${
                 isActive
-                  ? 'text-accent-main-100'
+                  ? 'reasoning-shimmer-text'
                   : isError
                     ? 'text-danger-100'
                     : 'text-text-200 group-hover/header:text-text-100'
@@ -354,21 +364,29 @@ export const ToolPartView = memo(function ToolPartView({
             </span>
 
             {title && (
-              <span className="text-[length:var(--fs-sm)] text-text-400 truncate min-w-0 flex-1 font-mono opacity-70">
+              <span
+                className={`text-[length:var(--fs-sm)] truncate min-w-0 flex-1 font-mono ${
+                  isActive ? 'reasoning-shimmer-text' : 'text-text-400 opacity-70'
+                }`}
+              >
                 {title}
               </span>
             )}
           </div>
 
           <div className="flex items-center gap-2 ml-auto shrink-0">
-            {duration !== undefined && state.status === 'completed' && (
-              <span className="text-[length:var(--fs-xxs)] font-mono text-text-500 tabular-nums transition-opacity duration-300">
+            {duration !== undefined && (state.status === 'completed' || isActive) && (
+              <span
+                className={`text-[length:var(--fs-xxs)] font-mono tabular-nums transition-opacity duration-300 ${
+                  isActive ? 'reasoning-shimmer-text' : 'text-text-500'
+                }`}
+              >
                 {formatDuration(duration)}
               </span>
             )}
             <span
               className={`text-[length:var(--fs-xxs)] font-medium transition-all duration-300 ${
-                isActive ? 'opacity-100 text-accent-main-100' : 'opacity-0 w-0 overflow-hidden'
+                isActive ? 'opacity-100 text-text-400' : 'opacity-0 w-0 overflow-hidden'
               }`}
             >
               {t('toolPart.running')}

--- a/src/hooks/useGlobalEvents.test.tsx
+++ b/src/hooks/useGlobalEvents.test.tsx
@@ -15,6 +15,8 @@ const {
   getSoundSnapshotMock,
   isSystemEnabledMock,
   activeSessionStoreMock,
+  applyServerConnectedTimestampMock,
+  getActiveServerIdMock,
 } = vi.hoisted(() => ({
   subscribeToEventsMock: vi.fn(),
   getSessionStatusMock: vi.fn(() => Promise.resolve({})),
@@ -26,6 +28,8 @@ const {
   notificationPushMock: vi.fn(),
   playNotificationSoundDedupedMock: vi.fn(),
   isSystemEnabledMock: vi.fn((type: string) => type !== 'permission'),
+  applyServerConnectedTimestampMock: vi.fn(),
+  getActiveServerIdMock: vi.fn(() => 'local'),
   getSoundSnapshotMock: vi.fn(() => ({
     currentSessionEnabled: true,
   })),
@@ -72,6 +76,10 @@ vi.mock('../store', () => ({
   },
   paneLayoutStore: {
     getFocusedSessionId: getFocusedSessionIdMock,
+  },
+  serverStore: {
+    applyServerConnectedTimestamp: applyServerConnectedTimestampMock,
+    getActiveServerId: getActiveServerIdMock,
   },
 }))
 
@@ -120,6 +128,8 @@ describe('useGlobalEvents', () => {
     playNotificationSoundDedupedMock.mockReset()
     getSoundSnapshotMock.mockReset()
     isSystemEnabledMock.mockReset()
+    applyServerConnectedTimestampMock.mockReset()
+    getActiveServerIdMock.mockReset()
     Object.values(activeSessionStoreMock).forEach(value => {
       if (typeof value === 'function' && 'mockClear' in value) value.mockClear()
     })
@@ -129,8 +139,25 @@ describe('useGlobalEvents', () => {
       currentSessionEnabled: true,
     })
     isSystemEnabledMock.mockImplementation((type: string) => type !== 'permission')
+    getActiveServerIdMock.mockReturnValue('local')
     activeSessionStoreMock.getSessionMeta.mockReturnValue({ title: 'Child Session', directory: '/workspace' })
     activeSessionStoreMock.getSnapshot.mockReturnValue({ statusMap: {} })
+  })
+
+  it('stores server clock calibration when server.connected arrives', async () => {
+    let callbacks: Parameters<typeof subscribeToEventsMock>[0] | undefined
+    subscribeToEventsMock.mockImplementation(cb => {
+      callbacks = cb
+      return vi.fn()
+    })
+
+    renderHook(() => useGlobalEvents())
+
+    await waitFor(() => expect(callbacks).toBeDefined())
+
+    callbacks!.onServerConnected?.({ timestamp: '2026-04-22T15:00:00.000Z' })
+
+    expect(applyServerConnectedTimestampMock).toHaveBeenCalledWith('local', '2026-04-22T15:00:00.000Z')
   })
 
   it('does not play current-session sound for child session events when parent session is focused', async () => {

--- a/src/hooks/useGlobalEvents.ts
+++ b/src/hooks/useGlobalEvents.ts
@@ -9,7 +9,7 @@
 // 4. 与具体 session 无关，处理所有 session 的事件
 
 import { useEffect, useRef } from 'react'
-import { messageStore, childSessionStore, paneLayoutStore } from '../store'
+import { messageStore, childSessionStore, paneLayoutStore, serverStore } from '../store'
 import { activeSessionStore } from '../store/activeSessionStore'
 import { notificationStore } from '../store/notificationStore'
 import { soundStore } from '../store/soundStore'
@@ -373,6 +373,10 @@ export function useGlobalEvents(directories?: string[]) {
         if (session.title && messageStore.getSessionState(session.id)) {
           messageStore.updateSessionMetadata(session.id, { title: session.title })
         }
+      },
+
+      onServerConnected: data => {
+        serverStore.applyServerConnectedTimestamp(serverStore.getActiveServerId(), data.timestamp)
       },
 
       // ============================================

--- a/src/hooks/useNow.ts
+++ b/src/hooks/useNow.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react'
+
+export function useNow(intervalMs = 1000, enabled = true): number {
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    if (!enabled) return
+
+    setNow(Date.now())
+    const timer = window.setInterval(() => setNow(Date.now()), intervalMs)
+    return () => window.clearInterval(timer)
+  }, [enabled, intervalMs])
+
+  return now
+}

--- a/src/store/serverStore.test.ts
+++ b/src/store/serverStore.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('serverStore clock calibration', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('derives calibrated now from a server timestamp and monotonic time', async () => {
+    const { serverStore } = await import('./serverStore')
+    const serverTimestamp = Date.parse('2026-04-22T15:00:00.000Z')
+    const perfSpy = vi.spyOn(performance, 'now')
+
+    perfSpy.mockReturnValueOnce(1_000)
+    expect(
+      serverStore.applyServerConnectedTimestamp(
+        serverStore.getActiveServerId(),
+        new Date(serverTimestamp).toISOString(),
+      ),
+    ).toBe(true)
+
+    perfSpy.mockReturnValue(1_750)
+    expect(serverStore.getActiveCalibratedNow()).toBe(serverTimestamp + 750)
+  })
+
+  it('ignores malformed timestamps', async () => {
+    const { serverStore } = await import('./serverStore')
+
+    expect(serverStore.applyServerConnectedTimestamp(serverStore.getActiveServerId(), 'not-a-date')).toBe(false)
+    expect(serverStore.getActiveCalibratedNow()).toBeUndefined()
+  })
+
+  it('does not reuse calibration after switching to another server without calibration', async () => {
+    const { serverStore } = await import('./serverStore')
+    const perfSpy = vi.spyOn(performance, 'now')
+
+    perfSpy.mockReturnValue(500)
+    serverStore.applyServerConnectedTimestamp(serverStore.getActiveServerId(), '2026-04-22T15:00:00.000Z')
+
+    const remote = serverStore.addServer({
+      name: 'Remote',
+      url: 'http://remote.test',
+    })
+    serverStore.setActiveServer(remote.id)
+
+    expect(serverStore.getActiveCalibratedNow()).toBeUndefined()
+  })
+})

--- a/src/store/serverStore.ts
+++ b/src/store/serverStore.ts
@@ -55,6 +55,11 @@ export interface ServerSettingsBackup {
   activeServerId: string | null
 }
 
+interface ServerClockCalibration {
+  serverTimestamp: number
+  calibratedAtMonotonic: number
+}
+
 type Listener = () => void
 
 const STORAGE_KEY = 'opencode-servers'
@@ -68,6 +73,7 @@ class ServerStore {
   private servers: ServerConfig[] = []
   private activeServerId: string | null = null
   private healthMap = new Map<string, ServerHealth>()
+  private clockCalibrationMap = new Map<string, ServerClockCalibration>()
   private listeners: Set<Listener> = new Set()
 
   // server 切换监听器（用于触发 SSE 重连等副作用，避免循环依赖）
@@ -167,7 +173,9 @@ class ServerStore {
 
   private notify(): void {
     this.updateSnapshots()
-    this.listeners.forEach(l => l())
+    this.listeners.forEach(l => {
+      l()
+    })
   }
 
   /**
@@ -243,6 +251,12 @@ class ServerStore {
     return this._healthMapSnapshot
   }
 
+  getActiveCalibratedNow(): number | undefined {
+    const calibration = this.clockCalibrationMap.get(this.getActiveServerId())
+    if (!calibration) return undefined
+    return calibration.serverTimestamp + (performance.now() - calibration.calibratedAtMonotonic)
+  }
+
   // ============================================
   // Mutations
   // ============================================
@@ -292,6 +306,7 @@ class ServerStore {
 
     this.servers = this.servers.filter(s => s.id !== id)
     this.healthMap.delete(id)
+    this.clockCalibrationMap.delete(id)
 
     // 如果删除的是当前选中的，切换到默认
     if (this.activeServerId === id) {
@@ -317,9 +332,23 @@ class ServerStore {
 
     // 实际切换了服务器，通知外部（SSE 重连等）
     if (changed) {
-      this.serverChangeListeners.forEach(fn => fn(id))
+      this.serverChangeListeners.forEach(fn => {
+        fn(id)
+      })
     }
 
+    return true
+  }
+
+  applyServerConnectedTimestamp(serverId: string, timestamp: unknown): boolean {
+    const normalizedTimestamp = normalizeServerTimestamp(timestamp)
+    if (normalizedTimestamp == null) return false
+
+    this.clockCalibrationMap.set(serverId, {
+      serverTimestamp: normalizedTimestamp,
+      calibratedAtMonotonic: performance.now(),
+    })
+    this.notify()
     return true
   }
 
@@ -502,4 +531,17 @@ export function importServerSettingsBackup(raw: unknown): void {
  */
 export function makeBasicAuthHeader(auth: ServerAuth): string {
   return 'Basic ' + btoa(`${auth.username}:${auth.password}`)
+}
+
+function normalizeServerTimestamp(timestamp: unknown): number | null {
+  if (typeof timestamp === 'number') {
+    return Number.isFinite(timestamp) ? timestamp : null
+  }
+
+  if (typeof timestamp === 'string') {
+    const parsed = Date.parse(timestamp)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+
+  return null
 }

--- a/src/types/api/event.ts
+++ b/src/types/api/event.ts
@@ -65,6 +65,10 @@ export type WorktreeFailedPayload = SDKEventWorktreeFailed['properties']
 
 export type VcsBranchUpdatedPayload = SDKEventVcsBranchUpdated['properties']
 
+export interface ServerConnectedPayload {
+  timestamp?: unknown
+}
+
 // ============================================
 // Global Event Type
 // ============================================
@@ -152,6 +156,7 @@ export interface EventCallbacks {
   onPartUpdated?: (part: Part) => void
   onPartDelta?: (data: PartDeltaPayload) => void
   onPartRemoved?: (data: PartRemovedPayload) => void
+  onServerConnected?: (data: ServerConnectedPayload) => void
   onSessionCreated?: (session: Session) => void
   onSessionUpdated?: (session: Session) => void
   onSessionDeleted?: (sessionId: string) => void

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -107,6 +107,7 @@ export type {
   GlobalEvent,
   EventType,
   EventCallbacks,
+  ServerConnectedPayload,
   SessionIdlePayload,
   SessionErrorPayload,
   SessionStatusPayload,


### PR DESCRIPTION
## Summary
- add live running tool durations before completion and keep the running-state animation aligned with the existing UI
- calibrate active timing from server.connected timestamps so running durations stay stable against local clock drift
- extract a shared ticking hook and add targeted tests for events, calibration, and tool duration rendering

Fixes #74.