### PR TITLE
fix: PWA safe-area double padding and chat bottom spacing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -563,10 +563,7 @@ function App() {
   const { showCloseDialog, handleCloseDialogConfirm, handleCloseDialogCancel } = useCloseServiceDialog()
 
   return (
-    <div
-      className="relative flex h-[var(--app-height)] flex-col bg-bg-100 overflow-hidden"
-      style={{ paddingTop: 'var(--safe-area-inset-top)' }}
-    >
+    <div className="relative flex h-full flex-col bg-bg-100 overflow-hidden">
       <DesktopTitlebar />
       <ChatViewportProvider value={chatViewport}>
         <div className="relative flex min-h-0 flex-1 overflow-hidden">

--- a/src/features/chat/ChatArea.tsx
+++ b/src/features/chat/ChatArea.tsx
@@ -446,11 +446,14 @@ export const ChatArea = memo(
             {/* Shim: flex-1 占满剩余空间，消息不满一屏时推到视觉顶部 */}
             <div className="flex-1" />
 
-            {/* Bottom spacing (视觉底部) */}
+            {/* Bottom spacing (视觉底部)：
+             * 预留一块高 = inputBoxHeight + GAP 的空区，让最后一条消息不被贴底的 InputBox 遮住。
+             * GAP 控制消息底部 (fork/copy 按钮一行) 到输入胶囊顶部的空白，
+             * 实际可见 gap = GAP + 消息卡 py-3 (12px)。默认 16px → 总 28px 视觉距离。 */}
             <div
               className="shrink-0"
               style={{
-                height: bottomPadding > 0 ? `${bottomPadding + 48}px` : '256px',
+                height: bottomPadding > 0 ? `${bottomPadding + 16}px` : '256px',
               }}
             />
 

--- a/src/features/chat/InputBox.tsx
+++ b/src/features/chat/InputBox.tsx
@@ -889,13 +889,15 @@ function InputBoxComponent({
   })
 
   // 底部 padding 计算：
-  // - isCollapsed (收起态，无 Footer)：safe-area + 12px 呼吸空间。
+  // - isCollapsed (收起态 / 移动端「回复胶囊」)：
+  //   公式 max(12, env)。Safari env()=0 → 12px breathing；PWA env()=34 → 34px，
+  //   胶囊底部刚好贴 safe-area 顶部，避免 env+12 叠加出现的「多一截」间距。
   // - 展开态：Footer (h-8 = 2rem) 已是一个天然的视觉缓冲，只需补足 safe-area
   //   超出 Footer 的部分。这避免 PWA 下 Footer + 完整 safe-area 叠加出现
-  //   「双倍 safe-area」的视觉 gap (Safari env()=0 看不出问题、PWA env()=34 问题明显)。
+  //   「双倍 safe-area」的视觉 gap。
   //   公式：max(0, env - 2rem) → 总缓冲 = Footer + padding = max(32px, env)
   const bottomDockPadding = isCollapsed
-    ? 'calc(var(--safe-area-inset-bottom, 0px) + 12px)'
+    ? 'max(12px, var(--safe-area-inset-bottom, 0px))'
     : 'max(0px, calc(var(--safe-area-inset-bottom, 0px) - 2rem))'
 
   return (

--- a/src/features/chat/InputBox.tsx
+++ b/src/features/chat/InputBox.tsx
@@ -888,9 +888,15 @@ function InputBoxComponent({
     if (a.agentName) excludeValues.add(a.agentName)
   })
 
+  // 底部 padding 计算：
+  // - isCollapsed (收起态，无 Footer)：safe-area + 12px 呼吸空间。
+  // - 展开态：Footer (h-8 = 2rem) 已是一个天然的视觉缓冲，只需补足 safe-area
+  //   超出 Footer 的部分。这避免 PWA 下 Footer + 完整 safe-area 叠加出现
+  //   「双倍 safe-area」的视觉 gap (Safari env()=0 看不出问题、PWA env()=34 问题明显)。
+  //   公式：max(0, env - 2rem) → 总缓冲 = Footer + padding = max(32px, env)
   const bottomDockPadding = isCollapsed
     ? 'calc(var(--safe-area-inset-bottom, 0px) + 12px)'
-    : 'var(--safe-area-inset-bottom, 0px)'
+    : 'max(0px, calc(var(--safe-area-inset-bottom, 0px) - 2rem))'
 
   return (
     <div className="w-full">

--- a/src/hooks/useViewportHeight.ts
+++ b/src/hooks/useViewportHeight.ts
@@ -20,24 +20,56 @@ export function useViewportHeight() {
       window.addEventListener('resize', updateAppHeight)
       return () => window.removeEventListener('resize', updateAppHeight)
     }
+    // Browser/PWA: 用 visualViewport 检测键盘。
+    //
+    // 陷阱：iOS PWA standalone 下 window.innerHeight 包含 home indicator 区域，
+    // 而 visualViewport.height 不包含。没键盘时两者差值 ≈ safe-area-inset-bottom（~34px），
+    // 会被误判为“键盘弹出”。需减掉这部分才是真实键盘高度。
+    // 不减的后果：#root 多出 34px padding-bottom + InputBox 自身又读一次
+    // var(--safe-area-inset-bottom) → 双倍 safe-area 间距。
+    //
+    // env(safe-area-inset-bottom) 在 CSS 自定义属性里不会被 getComputedStyle 解析为像素，
+    // 用临时 probe 元素把它赋给实际 padding 属性才能获得解析后的 px 值。
+    let safeAreaBottomPx = 0
+    const measureSafeAreaBottom = () => {
+      const probe = document.createElement('div')
+      probe.style.cssText =
+        'position:fixed;left:-9999px;top:0;width:0;height:0;' +
+        'padding-bottom:env(safe-area-inset-bottom,0px);' +
+        'visibility:hidden;pointer-events:none'
+      document.body.appendChild(probe)
+      safeAreaBottomPx = parseFloat(getComputedStyle(probe).paddingBottom) || 0
+      document.body.removeChild(probe)
+    }
+    measureSafeAreaBottom()
 
-    // Browser/PWA: 用 visualViewport 检测键盘
     const updateViewport = () => {
       const viewport = window.visualViewport
       if (!viewport) return
-      const inset = Math.max(0, window.innerHeight - viewport.height - viewport.offsetTop)
-      root.style.setProperty('--keyboard-inset-bottom', `${Math.round(inset)}px`)
+      const rawInset = window.innerHeight - viewport.height - viewport.offsetTop
+      // 减掉 safe-area phantom，剩下的才是真实键盘高度。
+      const keyboardInset = Math.max(0, rawInset - safeAreaBottomPx)
+      root.style.setProperty('--keyboard-inset-bottom', `${Math.round(keyboardInset)}px`)
     }
+
+    // 旋转设备 / 窗口 resize 时 safe-area 可能变化，重测一次。
+    const handleWindowResize = () => {
+      measureSafeAreaBottom()
+      updateViewport()
+    }
+
     updateViewport()
     if (window.visualViewport) {
       window.visualViewport.addEventListener('resize', updateViewport)
       window.visualViewport.addEventListener('scroll', updateViewport)
     }
+    window.addEventListener('resize', handleWindowResize)
     return () => {
       if (window.visualViewport) {
         window.visualViewport.removeEventListener('resize', updateViewport)
         window.visualViewport.removeEventListener('scroll', updateViewport)
       }
+      window.removeEventListener('resize', handleWindowResize)
     }
   }, [])
 }

--- a/src/index.css
+++ b/src/index.css
@@ -50,28 +50,32 @@ body,
   background: hsl(var(--bg-100));
 }
 
-/* PWA 全屏模式 / Tauri 原生 app 适配 - 只在 #root 上应用 safe area */
-@media (display-mode: standalone) {
-  #root {
-    padding-top: var(--safe-area-inset-top);
-    padding-left: var(--safe-area-inset-left);
-    padding-right: var(--safe-area-inset-right);
-    /* 不在这里加 padding-bottom，让 InputBox 自己处理 */
-  }
+/* Safe-area padding 应用在 #root 上：浏览器、PWA、Tauri 共用同一份 env()。
+ * 非 PWA 浏览器场景下 env() 自然返回 0，不会产生副作用；Tauri 走原生 setPadding，
+ * 由下方 .tauri-app #root 显式重置为 0，避免与原生层叠加产生双倍 padding。
+ * 不在这里加 padding-bottom——贴底组件 (InputBox / BottomPanel / SidebarFooter)
+ * 自己读取 var(--safe-area-inset-bottom) 处理底边距，避免和键盘 inset 冲突。 */
+#root {
+  padding-top: var(--safe-area-inset-top);
+  padding-left: var(--safe-area-inset-left);
+  padding-right: var(--safe-area-inset-right);
+}
 
-  /* PWA standalone 底部兜底：
-   * 部分 iOS 设备（如有物理 Home 键的 iPhone 8）env(safe-area-inset-bottom) 为 0，
-   * 但 Safari standalone 仍会在底部叠加系统 UI 横条，遮住贴底内容。
-   * 用 max() 取 safe-area 和最小保底值的较大者，确保 InputFooter 不被遮挡。 */
+/* PWA standalone 底部兜底：
+ * 部分 iOS 设备（如有物理 Home 键的 iPhone 8）env(safe-area-inset-bottom) 为 0，
+ * 但 Safari standalone 仍会在底部叠加系统 UI 横条，遮住贴底内容。
+ * 用 max() 取 safe-area 和最小保底值的较大者，确保 InputFooter 不被遮挡。 */
+@media (display-mode: standalone) {
   :root:not(.tauri-app) {
     --safe-area-inset-bottom: max(env(safe-area-inset-bottom, 0px), 8px);
   }
 }
 
-/* Tauri 原生 app：原生层 MainActivity.kt 已经通过 setPadding 处理了安全区域和键盘 */
-/* safe area padding 由原生层管理，CSS 侧不再重复处理 */
+/* Tauri 原生 app：原生 MainActivity.kt 通过 setPadding 处理 safe-area 和键盘。
+ * 用更高优先级 (.tauri-app + #root) 显式 padding:0 覆盖上面的 #root 规则，
+ * 防止 CSS env() 与原生 setPadding 双重叠加。 */
 .tauri-app #root {
-  /* 原生已 setPadding，这里不再加 padding */
+  padding: 0;
 }
 
 /* ============================================


### PR DESCRIPTION
## Summary

Two related fixes for the iOS PWA experience and the chat surface bottom layout. Discovered while testing the installed PWA on iPhone — the symptoms compounded into visible "double safe-area" gaps below the input box and oversized empty space below message action rows.

## Changes

### 1. PWA safe-area double padding on iOS (`fix: PWA safe-area double padding on iOS`)

Three independent sources of bottom-area padding were stacking in PWA standalone mode:

- **`#root` padding-top applied twice.** The `@media (display-mode: standalone)` rule on `#root` and an inline `paddingTop: var(--safe-area-inset-top)` on `App.tsx`'s root div both fired in standalone mode → top status-bar gap was doubled.
  - `index.css`: drop the standalone media gate, apply `#root` safe-area padding unconditionally (browser env() returns 0, no side effect). Reset to 0 on `.tauri-app` so the Tauri native `setPadding` isn't doubled.
  - `App.tsx`: remove the inline `paddingTop` and switch `h-[var(--app-height)]` → `h-full` so the root div fits inside `#root`'s content box instead of extending 100dvh past the viewport bottom (which was getting clipped, hiding the InputBox bottom).

- **`visualViewport` phantom keyboard inset.** `useViewportHeight` was setting `--keyboard-inset-bottom = window.innerHeight - visualViewport.height` directly. On iOS PWA standalone the home-indicator height (~34px) is reported in this diff even with no keyboard, so `#root` was getting 34px of phantom bottom padding.
  - `useViewportHeight.ts`: probe `env(safe-area-inset-bottom)` via a temporary element (CSS custom properties don't resolve `env()` for `getComputedStyle`), then subtract that from the visualViewport diff. Real keyboards survive; the home-indicator phantom is filtered.

- **InputBox wrapper stacking with the 32px Footer.** The expanded-mode wrapper added `var(--safe-area-inset-bottom)` (34px) of `padding-bottom` _below_ the already-32px `InputFooter`. In Safari (`env() = 0`) it looked normal; in PWA the gap below the input toolbar was 66px ≈ 2× safe-area.
  - `InputBox.tsx`: in expanded mode use `max(0, env - 2rem)` so Footer (h-8) itself absorbs the safe-area buffer. Total bottom buffer = `max(32px, env)` — never less than the Footer height, never less than the safe area.

### 2. Tighten chat surface bottom spacing (`fix: tighten chat surface bottom spacing`)

Two visual gaps below the chat scroll felt oversized after the safe-area fix shrank the InputBox; they were already a bit generous in Safari but became more obvious once the input dock sat lower.

- **`ChatArea.tsx`**: drop hardcoded `+ 48px` scroll bottom reservation to `+ 16px`. Visible gap from the message card's action row (fork/copy buttons) to the input capsule top = 16 + 12 (message card `py-3`) = **28px** instead of 60px. Affects both Safari and PWA.

- **`InputBox.tsx` collapsed dock**: switch `env + 12px` → `max(12px, env)`. Safari (`env = 0`) is unchanged at 12px. PWA (`env = 34`) drops from 46px to 34px so the reply capsule's bottom edge sits exactly at the safe-area top instead of floating an extra 12px above it. PWA-only behavior change.

## Verification

- `tsc -b` clean
- `vite build` clean
- Tested on iPhone Safari (browser) vs PWA standalone (Add to Home Screen)
  - Top: status bar gap is correct in both modes (no double padding in PWA, no missing padding in browser)
  - Bottom: input capsule sits at safe-area top in PWA; bottom scroll padding feels consistent between modes
  - Keyboard show/hide: input dock follows the keyboard correctly without phantom gap when keyboard is closed
- Tauri desktop unaffected (`.tauri-app #root { padding: 0 }` keeps the existing native-padding flow)

## Notes

- Each fix has comments explaining the root cause and the formula used, so the next person modifying these files won't reintroduce the stacked-padding pattern.
- The 28px chat bottom gap is the only universal change here — happy to revisit if the original 60px was intentional for a use case I'm not aware of.