### PR TITLE
fix: consolidate drawer bottom safe-area padding

### DIFF
--- a/src/components/BottomPanel.tsx
+++ b/src/components/BottomPanel.tsx
@@ -223,7 +223,6 @@ export const BottomPanel = memo(function BottomPanel({ directory }: BottomPanelP
       maxSize={layout.bottomPanel.maxHeight}
       onSizeChange={h => layoutStore.setBottomPanelHeight(h)}
       onClose={() => layoutStore.closeBottomPanel()}
-      className="pb-[var(--safe-area-inset-bottom)]"
     >
       <PanelContainer
         position="bottom"

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -161,7 +161,6 @@ export const RightPanel = memo(function RightPanel({ directory, sessionId }: Rig
       maxSize={layout.rightPanel.resizeMaxWidth}
       onSizeChange={w => layoutStore.setRightPanelWidth(w)}
       onClose={() => layoutStore.closeRightPanel()}
-      className="pb-[var(--safe-area-inset-bottom)]"
     >
       <PanelContainer
         position="right"

--- a/src/components/ui/ResizablePanel.tsx
+++ b/src/components/ui/ResizablePanel.tsx
@@ -32,7 +32,6 @@ export const ResizablePanel = memo(function ResizablePanel({
   const { preferTouchUi, hasCoarsePointer, hasTouch } = useInputCapabilities()
   const touchCapable = preferTouchUi || hasCoarsePointer || hasTouch
   const [isResizing, setIsResizing] = useState(false)
-  const safeBottomInset = 'var(--safe-area-inset-bottom, 0px)'
   const panelRef = useRef<HTMLDivElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
   const rafRef = useRef<number>(0)
@@ -208,7 +207,6 @@ export const ResizablePanel = memo(function ResizablePanel({
         ? ({
             top: 'calc(var(--safe-area-inset-top, 0px) + var(--desktop-titlebar-height, 0px))',
             height: 'calc(100% - var(--safe-area-inset-top, 0px) - var(--desktop-titlebar-height, 0px))',
-            paddingBottom: safeBottomInset,
           } as React.CSSProperties)
         : ({} as React.CSSProperties)
 
@@ -242,7 +240,7 @@ export const ResizablePanel = memo(function ResizablePanel({
             </div>
           )}
 
-          <div ref={contentRef} className="flex-1 flex flex-col min-h-0 min-w-0 w-full h-full relative bg-bg-100">
+          <div ref={contentRef} className="flex-1 flex flex-col min-h-0 min-w-0 w-full h-full relative bg-bg-100 pb-[var(--safe-area-inset-bottom)]">
             {children}
           </div>
         </div>
@@ -293,7 +291,7 @@ export const ResizablePanel = memo(function ResizablePanel({
 
       {isResizing && <div className="absolute inset-0 z-40 bg-transparent pointer-events-auto" />}
 
-      <div ref={contentRef} className="absolute inset-0 flex flex-col min-h-0 min-w-0 w-full h-full">
+      <div ref={contentRef} className="absolute inset-0 flex flex-col min-h-0 min-w-0 w-full h-full pb-[var(--safe-area-inset-bottom)]">
         {children}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Cleans up the bottom safe-area padding handling on the right/bottom drawer overlays so they follow the same pattern as the left `Sidebar` (inner sticky-bottom component handles its own pb), which is also the convention documented in `index.css:53-57`.

## Changes

- `ResizablePanel.tsx`: removed the inline `paddingBottom: safeBottomInset` (only set for right overlay) and the now-unused `safeBottomInset` constant. Added `pb-[var(--safe-area-inset-bottom)]` to both the overlay and docked `contentRef` wrappers — the inner content surface now owns safe-area-bottom.
- `RightPanel.tsx` / `BottomPanel.tsx`: dropped the `className=\"pb-[var(--safe-area-inset-bottom)]\"` they were passing into `ResizablePanel` (no longer needed; ResizablePanel handles it internally).
- `Sidebar.tsx` untouched — `SidebarFooter` already handles its own pb correctly.

## Why

Previously the right drawer overlay had **two sources** of `padding-bottom: var(--safe-area-inset-bottom)` on the same element (caller className + ResizablePanel inline style). Inline won, so it wasn't visually doubled, but it was redundant code with two owners.

While moving the padding to the inner content wrapper, also fixed a **latent docked-mode bug**: in the docked branch `contentRef` is `absolute inset-0`, which fills the parent's padding box, not the content box. That meant the outer `pb-[var(--safe-area-inset-bottom)]` from RightPanel/BottomPanel had **no effect** on inner content positioning. Putting the padding directly on `contentRef` makes the safe area actually reduce content area in both overlay and docked modes.

## Validation

- `npm run validate` (typecheck + lint + tests + build) passes.
- LSP diagnostics clean on all three changed files.