### PR TITLE
fix: 切换目录时保留会话状态

### DIFF
--- a/src/hooks/useFileExplorer.test.tsx
+++ b/src/hooks/useFileExplorer.test.tsx
@@ -76,4 +76,60 @@ describe('useFileExplorer change scope', () => {
     expect(result.current.fileStatus.get('src/session.ts')).toBeUndefined()
     expect(getLastTurnDiff).toHaveBeenCalledWith('session-1', '/repo')
   })
+
+  it('restores expanded folders per directory when switching projects', async () => {
+    listDirectory.mockImplementation(async (parentPath: string, directory: string) => {
+      if (parentPath === '') {
+        return [{ name: 'src', path: 'src', absolute: `${directory}/src`, type: 'directory', ignored: false }]
+      }
+
+      if (parentPath === 'src') {
+        return [
+          {
+            name: directory === '/repo-a' ? 'a.ts' : 'b.ts',
+            path: `src/${directory === '/repo-a' ? 'a.ts' : 'b.ts'}`,
+            absolute: `${directory}/src/${directory === '/repo-a' ? 'a.ts' : 'b.ts'}`,
+            type: 'file',
+            ignored: false,
+          },
+        ]
+      }
+
+      return []
+    })
+
+    const { result, rerender } = renderHook(
+      ({ directory }) => useFileExplorer({ directory, autoLoad: true }),
+      { initialProps: { directory: '/repo-a' } },
+    )
+
+    await waitFor(() => {
+      expect(result.current.tree).toHaveLength(1)
+    })
+
+    act(() => {
+      result.current.toggleExpand('src')
+    })
+
+    await waitFor(() => {
+      expect(result.current.expandedPaths.has('src')).toBe(true)
+      expect(result.current.tree[0]?.children?.[0]?.path).toBe('src/a.ts')
+    })
+
+    rerender({ directory: '/repo-b' })
+
+    await waitFor(() => {
+      expect(result.current.tree[0]?.absolute).toBe('/repo-b/src')
+      expect(result.current.tree[0]?.children?.[0]?.path).toBeUndefined()
+      expect(result.current.expandedPaths.has('src')).toBe(false)
+    })
+
+    rerender({ directory: '/repo-a' })
+
+    await waitFor(() => {
+      expect(result.current.tree[0]?.absolute).toBe('/repo-a/src')
+      expect(result.current.expandedPaths.has('src')).toBe(true)
+      expect(result.current.tree[0]?.children?.[0]?.path).toBe('src/a.ts')
+    })
+  })
 })

--- a/src/hooks/useFileExplorer.ts
+++ b/src/hooks/useFileExplorer.ts
@@ -60,6 +60,7 @@ export function useFileExplorer(options: UseFileExplorerOptions = {}): UseFileEx
 
   // 展开状态
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set())
+  const expandedPathsByDirectoryRef = useRef<Map<string, Set<string>>>(new Map())
 
   // 预览状态
   const [previewContent, setPreviewContent] = useState<FileContent | null>(null)
@@ -190,10 +191,23 @@ export function useFileExplorer(options: UseFileExplorerOptions = {}): UseFileEx
     [directory],
   )
 
+  const updateExpandedPaths = useCallback(
+    (updater: (prev: Set<string>) => Set<string>) => {
+      setExpandedPaths(prev => {
+        const next = updater(prev)
+        if (directory) {
+          expandedPathsByDirectoryRef.current.set(directory, new Set(next))
+        }
+        return next
+      })
+    },
+    [directory],
+  )
+
   // 切换展开/折叠
   const toggleExpand = useCallback(
     (path: string) => {
-      setExpandedPaths(prev => {
+      updateExpandedPaths(prev => {
         const next = new Set(prev)
         if (next.has(path)) {
           next.delete(path)
@@ -208,12 +222,12 @@ export function useFileExplorer(options: UseFileExplorerOptions = {}): UseFileEx
         return next
       })
     },
-    [tree, loadChildren],
+    [tree, loadChildren, updateExpandedPaths],
   )
 
   const expandPath = useCallback(
     (path: string) => {
-      setExpandedPaths(prev => {
+      updateExpandedPaths(prev => {
         const next = new Set(prev)
         next.add(path)
         return next
@@ -223,16 +237,16 @@ export function useFileExplorer(options: UseFileExplorerOptions = {}): UseFileEx
         loadChildren(path)
       }
     },
-    [tree, loadChildren],
+    [tree, loadChildren, updateExpandedPaths],
   )
 
   const collapsePath = useCallback((path: string) => {
-    setExpandedPaths(prev => {
+    updateExpandedPaths(prev => {
       const next = new Set(prev)
       next.delete(path)
       return next
     })
-  }, [])
+  }, [updateExpandedPaths])
 
   // 加载文件预览
   const loadPreview = useCallback(
@@ -280,11 +294,14 @@ export function useFileExplorer(options: UseFileExplorerOptions = {}): UseFileEx
 
   // 刷新
   const refresh = useCallback(async () => {
+    if (directory) {
+      expandedPathsByDirectoryRef.current.delete(directory)
+    }
     setExpandedPaths(new Set())
     previewCacheRef.current.clear()
     setPreviewContent(null)
     await Promise.all([loadRoot(), loadStatuses()])
-  }, [loadRoot, loadStatuses])
+  }, [directory, loadRoot, loadStatuses])
 
   // 初始加载
   useEffect(() => {
@@ -298,6 +315,27 @@ export function useFileExplorer(options: UseFileExplorerOptions = {}): UseFileEx
       loadStatuses()
     }
   }, [autoLoad, directory, loadStatuses])
+
+  useEffect(() => {
+    if (!directory) {
+      setExpandedPaths(new Set())
+      return
+    }
+
+    const storedPaths = expandedPathsByDirectoryRef.current.get(directory)
+    setExpandedPaths(storedPaths ? new Set(storedPaths) : new Set())
+  }, [directory])
+
+  useEffect(() => {
+    if (!directory || tree.length === 0 || expandedPaths.size === 0) return
+
+    const pendingPaths = collectPendingExpandedDirectoryPaths(tree, expandedPaths)
+    if (pendingPaths.length === 0) return
+
+    pendingPaths.forEach(path => {
+      void loadChildren(path)
+    })
+  }, [directory, expandedPaths, loadChildren, tree])
 
   useEffect(() => {
     previewCacheRef.current.clear()
@@ -369,6 +407,30 @@ function updateTreeNode(
     }
     return node
   })
+}
+
+function collectPendingExpandedDirectoryPaths(tree: FileTreeNode[], expandedPaths: Set<string>): string[] {
+  const pending: string[] = []
+
+  const visit = (nodes: FileTreeNode[]) => {
+    for (const node of nodes) {
+      if (node.type !== 'directory') continue
+
+      if (expandedPaths.has(node.path)) {
+        if (!node.isLoaded && !node.isLoading) {
+          pending.push(node.path)
+          continue
+        }
+      }
+
+      if (node.children) {
+        visit(node.children)
+      }
+    }
+  }
+
+  visit(tree)
+  return pending
 }
 
 // Helper: 规范化路径 — 统一分隔符为 /，去掉前导 ./

--- a/src/hooks/useGlobalEvents.ts
+++ b/src/hooks/useGlobalEvents.ts
@@ -262,7 +262,7 @@ function isSessionDirectlyOpen(sessionId: string): boolean {
 
 export function useGlobalEvents(directories?: string[]) {
   const directoriesRef = useRef<string[] | undefined>(directories)
-  const refreshRef = useRef<(() => void) | null>(null)
+  const refreshRef = useRef<((mode?: 'replace' | 'merge') => void) | null>(null)
   const initializedDirectoriesRef = useRef(false)
 
   useEffect(() => {
@@ -303,14 +303,14 @@ export function useGlobalEvents(directories?: string[]) {
     // 拉取 session 状态 + pending requests（初始化 & 重连共用）
     // ============================================
 
-    const fetchAndInitialize = () => {
+    const fetchAndInitialize = (mode: 'replace' | 'merge' = 'replace') => {
       const currentVersion = ++fetchVersion
       activeFetchVersion = currentVersion
       void fetchActiveScopeData(directoriesRef.current)
         .then(({ statusMap, permissions, questions, sessionMetaEntries }) => {
           if (disposed || currentVersion !== fetchVersion) return
-          activeSessionStore.initialize(statusMap)
-          activeSessionStore.initializePendingRequests(permissions, questions)
+          activeSessionStore.initialize(statusMap, { mode })
+          activeSessionStore.initializePendingRequests(permissions, questions, { mode })
           const currentDirectories = directoriesRef.current
           const currentScopeKey = getScopeKey(directoriesRef.current)
           for (const pending of latePendingRequests.values()) {
@@ -605,7 +605,7 @@ export function useGlobalEvents(directories?: string[]) {
   useLayoutEffect(() => {
     directoriesRef.current = directories
     if (initializedDirectoriesRef.current) {
-      refreshRef.current?.()
+      refreshRef.current?.('merge')
       return
     }
     initializedDirectoriesRef.current = true

--- a/src/store/activeSessionStore.test.ts
+++ b/src/store/activeSessionStore.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { activeSessionStore } from './activeSessionStore'
+
+describe('activeSessionStore scoped refresh handling', () => {
+  beforeEach(() => {
+    activeSessionStore.initialize({})
+    activeSessionStore.initializePendingRequests([], [])
+  })
+
+  it('preserves existing busy child sessions when merging scoped status refreshes', () => {
+    activeSessionStore.initialize({
+      root: { type: 'busy' },
+      child: { type: 'busy' },
+    })
+
+    activeSessionStore.initialize(
+      {
+        root: { type: 'busy' },
+      },
+      { mode: 'merge' },
+    )
+
+    expect(activeSessionStore.getBusySessions().map(entry => entry.sessionId)).toEqual(['root', 'child'])
+  })
+
+  it('drops missing sessions on full status replacement refreshes', () => {
+    activeSessionStore.initialize({
+      root: { type: 'busy' },
+      child: { type: 'busy' },
+    })
+
+    activeSessionStore.initialize({
+      root: { type: 'busy' },
+    })
+
+    expect(activeSessionStore.getBusySessions().map(entry => entry.sessionId)).toEqual(['root'])
+  })
+
+  it('keeps existing pending child requests during scoped pending refresh merges', () => {
+    activeSessionStore.addPendingRequest('req-child', 'child', 'question', 'Need approval')
+
+    activeSessionStore.initializePendingRequests([], [], { mode: 'merge' })
+
+    expect(activeSessionStore.getBusySessions().map(entry => entry.sessionId)).toEqual(['child'])
+    expect(activeSessionStore.getBusySessions()[0]?.pendingAction).toEqual({
+      type: 'question',
+      description: 'Need approval',
+    })
+  })
+})

--- a/src/store/activeSessionStore.ts
+++ b/src/store/activeSessionStore.ts
@@ -48,6 +48,10 @@ interface ActiveSessionState {
   initialized: boolean
 }
 
+interface InitializeOptions {
+  mode?: 'replace' | 'merge'
+}
+
 type Subscriber = () => void
 
 // ============================================
@@ -81,7 +85,9 @@ class ActiveSessionStore {
 
   private notify() {
     this.recomputeDerived()
-    this.subscribers.forEach(cb => cb())
+    this.subscribers.forEach(cb => {
+      cb()
+    })
   }
 
   private recomputeDerived() {
@@ -121,12 +127,31 @@ class ActiveSessionStore {
   getBusySessionsSnapshot = (): ActiveSessionEntry[] => this.cachedBusySessions
   getBusyCountSnapshot = (): number => this.cachedBusyCount
 
+  private mergeStatusMap(statusMap: SessionStatusMap, mode: 'replace' | 'merge'): SessionStatusMap {
+    const nextMap = mode === 'merge' ? { ...this.state.statusMap } : {}
+
+    for (const [sessionId, status] of Object.entries(statusMap)) {
+      if (status.type === 'idle') {
+        delete nextMap[sessionId]
+        continue
+      }
+
+      nextMap[sessionId] = status.type === 'retry' ? { ...status } : { type: 'busy' }
+    }
+
+    return nextMap
+  }
+
   // ============================================
   // 初始化：从 API 拉取全量状态
   // ============================================
 
-  initialize(statusMap: SessionStatusMap) {
-    this.state = { statusMap: { ...statusMap }, initialized: true }
+  initialize(statusMap: SessionStatusMap, options: InitializeOptions = {}) {
+    const mode = options.mode ?? 'replace'
+    this.state = {
+      statusMap: this.mergeStatusMap(statusMap, mode),
+      initialized: true,
+    }
     this.notify()
   }
 
@@ -137,16 +162,18 @@ class ActiveSessionStore {
   initializePendingRequests(
     permissions: Array<{ id: string; sessionID: string; permission: string; patterns?: string[] }>,
     questions: Array<{ id: string; sessionID: string; questions?: Array<{ header?: string }> }>,
+    options: InitializeOptions = {},
   ) {
-    this.pendingRequests.clear()
-    this.deferredIdleSessions.clear()
+    const mode = options.mode ?? 'replace'
+    const pendingRequests = mode === 'merge' ? new Map(this.pendingRequests) : new Map<string, PendingRequest>()
+    const deferredIdleSessions = mode === 'merge' ? new Set(this.deferredIdleSessions) : new Set<string>()
 
     let changed = false
     const newMap = { ...this.state.statusMap }
 
     for (const p of permissions) {
       const desc = p.patterns?.length ? `${p.permission}: ${p.patterns[0]}` : p.permission
-      this.pendingRequests.set(p.id, {
+      pendingRequests.set(p.id, {
         requestId: p.id,
         sessionId: p.sessionID,
         type: 'permission',
@@ -154,14 +181,14 @@ class ActiveSessionStore {
       })
       if (!newMap[p.sessionID] || newMap[p.sessionID].type === 'idle') {
         newMap[p.sessionID] = { type: 'busy' }
-        this.deferredIdleSessions.add(p.sessionID)
+        deferredIdleSessions.add(p.sessionID)
         changed = true
       }
     }
 
     for (const q of questions) {
       const desc = q.questions?.[0]?.header || 'Waiting for input'
-      this.pendingRequests.set(q.id, {
+      pendingRequests.set(q.id, {
         requestId: q.id,
         sessionId: q.sessionID,
         type: 'question',
@@ -169,10 +196,13 @@ class ActiveSessionStore {
       })
       if (!newMap[q.sessionID] || newMap[q.sessionID].type === 'idle') {
         newMap[q.sessionID] = { type: 'busy' }
-        this.deferredIdleSessions.add(q.sessionID)
+        deferredIdleSessions.add(q.sessionID)
         changed = true
       }
     }
+
+    this.pendingRequests = pendingRequests
+    this.deferredIdleSessions = deferredIdleSessions
 
     if (changed) {
       this.state = { ...this.state, statusMap: newMap }


### PR DESCRIPTION
## 概要

- 切换项目目录时，按目录保留并恢复文件浏览器的展开状态（ https://github.com/lehhair/OpenCodeUI/issues/87#issue-4407843325 ）
- 为活动会话刷新增加 merge 模式，避免目录范围刷新时丢失子会话状态( https://github.com/lehhair/OpenCodeUI/issues/89#issue-4417547414 ）
- 增加文件浏览器目录切换和活动会话合并行为的回归测试

## 验证

- 增加了 `useFileExplorer` 的目录切换测试
- 增加了 `activeSessionStore` 的合并刷新测试