### PR TITLE
fix: 加固多窗口全局事件副作用与通知声音去重

### DIFF
--- a/src/hooks/useGlobalEvents.test.tsx
+++ b/src/hooks/useGlobalEvents.test.tsx
@@ -26,9 +26,12 @@ const {
   applyServerConnectedTimestampMock,
   getActiveServerIdMock,
   autoApproveStoreMock,
+  claimGlobalSideEffectMock,
 } = vi.hoisted(() => ({
   subscribeToEventsMock: vi.fn(),
-  getSessionStatusMock: vi.fn<(directory?: string) => Promise<Record<string, { type: string }>>>(() => Promise.resolve({})),
+  getSessionStatusMock: vi.fn<(directory?: string) => Promise<Record<string, { type: string }>>>(() =>
+    Promise.resolve({}),
+  ),
   getPendingPermissionsMock: vi.fn(() =>
     Promise.resolve([] as Array<{ id: string; sessionID: string; permission: string; patterns?: string[] }>),
   ),
@@ -64,6 +67,7 @@ const {
     claimAutoReply: vi.fn((_requestId: string) => true),
     releaseAutoReply: vi.fn((_requestId: string) => undefined),
   },
+  claimGlobalSideEffectMock: vi.fn(() => true),
 }))
 
 vi.mock('../api', () => ({
@@ -133,6 +137,10 @@ vi.mock('../store/autoApproveStore', () => ({
   autoApproveStore: autoApproveStoreMock,
 }))
 
+vi.mock('../utils/globalEventSideEffects', () => ({
+  claimGlobalSideEffect: claimGlobalSideEffectMock,
+}))
+
 describe('useGlobalEvents', () => {
   beforeEach(() => {
     subscribeToEventsMock.mockReset()
@@ -152,6 +160,7 @@ describe('useGlobalEvents', () => {
     autoApproveStoreMock.approvePendingOnFullAuto = false
     autoApproveStoreMock.subscribe.mockReset()
     autoApproveStoreMock.claimAutoReply.mockReset()
+    claimGlobalSideEffectMock.mockReset()
     autoApproveStoreMock.releaseAutoReply.mockReset()
     Object.values(activeSessionStoreMock).forEach(value => {
       if (typeof value === 'function' && 'mockClear' in value) value.mockClear()
@@ -165,6 +174,7 @@ describe('useGlobalEvents', () => {
     getActiveServerIdMock.mockReturnValue('local')
     autoApproveStoreMock.subscribe.mockReturnValue(vi.fn())
     autoApproveStoreMock.claimAutoReply.mockReturnValue(true)
+    claimGlobalSideEffectMock.mockReturnValue(true)
     activeSessionStoreMock.getSessionMeta.mockReturnValue({ title: 'Child Session', directory: '/workspace' })
     activeSessionStoreMock.getSnapshot.mockReturnValue({ statusMap: {} })
   })
@@ -424,6 +434,54 @@ describe('useGlobalEvents', () => {
       )
     })
     expect(autoApproveStoreMock.claimAutoReply).toHaveBeenCalledWith('perm-global')
+    expect(claimGlobalSideEffectMock).toHaveBeenCalledWith('auto-approve:perm-global', 10000)
+  })
+
+  it('does not auto approve a request already claimed by another window', async () => {
+    autoApproveStoreMock.fullAutoMode = 'global'
+    autoApproveStoreMock.approvePendingOnFullAuto = true
+    claimGlobalSideEffectMock.mockReturnValue(false)
+    getPendingPermissionsMock.mockResolvedValue([
+      {
+        id: 'perm-global',
+        sessionID: 'background-session',
+        permission: 'bash',
+        patterns: ['npm test'],
+      },
+    ])
+
+    renderHook(() => useGlobalEvents(['/workspace']))
+
+    await waitFor(() => expect(getPendingPermissionsMock).toHaveBeenCalled())
+
+    expect(autoApproveStoreMock.claimAutoReply).toHaveBeenCalledWith('perm-global')
+    expect(autoApproveStoreMock.releaseAutoReply).toHaveBeenCalledWith('perm-global')
+    expect(replyPermissionMock).not.toHaveBeenCalled()
+  })
+
+  it('releases a global full-auto permission event already claimed by another window', async () => {
+    let callbacks: Parameters<typeof subscribeToEventsMock>[0] | undefined
+    subscribeToEventsMock.mockImplementation(cb => {
+      callbacks = cb
+      return vi.fn()
+    })
+    autoApproveStoreMock.fullAutoMode = 'global'
+    claimGlobalSideEffectMock.mockReturnValue(false)
+
+    renderHook(() => useGlobalEvents())
+
+    await waitFor(() => expect(callbacks).toBeDefined())
+
+    callbacks!.onPermissionAsked?.({
+      id: 'perm-global-claimed',
+      sessionID: 'background-session',
+      permission: 'bash',
+      patterns: [],
+    })
+
+    expect(autoApproveStoreMock.claimAutoReply).toHaveBeenCalledWith('perm-global-claimed')
+    expect(autoApproveStoreMock.releaseAutoReply).toHaveBeenCalledWith('perm-global-claimed')
+    expect(replyPermissionMock).not.toHaveBeenCalled()
   })
 
   it('does not approve already waiting permissions when the pending sweep is disabled', async () => {
@@ -465,6 +523,80 @@ describe('useGlobalEvents', () => {
 
     expect(notificationPushMock).not.toHaveBeenCalled()
     expect(playNotificationSoundDedupedMock).toHaveBeenCalledWith('permission')
+    expect(claimGlobalSideEffectMock).toHaveBeenCalledWith('sound:permission:perm-2')
+  })
+
+  it('skips current-session sound already claimed by another window', async () => {
+    let callbacks: Parameters<typeof subscribeToEventsMock>[0] | undefined
+    subscribeToEventsMock.mockImplementation(cb => {
+      callbacks = cb
+      return vi.fn()
+    })
+    getFocusedSessionIdMock.mockReturnValue('child-session')
+    claimGlobalSideEffectMock.mockReturnValue(false)
+
+    renderHook(() => useGlobalEvents())
+
+    await waitFor(() => expect(callbacks).toBeDefined())
+
+    callbacks!.onPermissionAsked?.({
+      id: 'perm-claimed',
+      sessionID: 'child-session',
+      permission: 'bash',
+      patterns: [],
+    })
+
+    expect(activeSessionStoreMock.addPendingRequest).toHaveBeenCalledWith(
+      'perm-claimed',
+      'child-session',
+      'permission',
+      'bash',
+    )
+    expect(playNotificationSoundDedupedMock).not.toHaveBeenCalled()
+  })
+
+  it('uses the same sound claim key for current-session sound and background notification sound', async () => {
+    let callbacks: Parameters<typeof subscribeToEventsMock>[0] | undefined
+    subscribeToEventsMock.mockImplementation(cb => {
+      callbacks = cb
+      return vi.fn()
+    })
+    getFocusedSessionIdMock.mockReturnValue('child-session')
+
+    renderHook(() => useGlobalEvents())
+
+    await waitFor(() => expect(callbacks).toBeDefined())
+
+    callbacks!.onPermissionAsked?.({
+      id: 'perm-mixed-window',
+      sessionID: 'child-session',
+      permission: 'bash',
+      patterns: [],
+    })
+
+    expect(claimGlobalSideEffectMock).toHaveBeenCalledWith('sound:permission:perm-mixed-window')
+    expect(playNotificationSoundDedupedMock).toHaveBeenCalledWith('permission')
+
+    notificationPushMock.mockClear()
+    playNotificationSoundDedupedMock.mockClear()
+    getFocusedSessionIdMock.mockReturnValue(null)
+
+    callbacks!.onPermissionAsked?.({
+      id: 'perm-mixed-window',
+      sessionID: 'child-session',
+      permission: 'bash',
+      patterns: [],
+    })
+
+    expect(notificationPushMock).toHaveBeenCalledWith(
+      'permission',
+      'Child Session — Permission',
+      'bash',
+      'child-session',
+      '/workspace',
+      { soundKey: 'sound:permission:perm-mixed-window' },
+    )
+    expect(playNotificationSoundDedupedMock).not.toHaveBeenCalled()
   })
 
   it('still plays current-session sound when the matching system notification toggle is disabled', async () => {
@@ -540,4 +672,32 @@ describe('useGlobalEvents', () => {
       expect(playNotificationSoundDedupedMock).not.toHaveBeenCalled()
     },
   )
+
+  it('keeps state updates but skips background notification already claimed by another window', async () => {
+    let callbacks: Parameters<typeof subscribeToEventsMock>[0] | undefined
+    subscribeToEventsMock.mockImplementation(cb => {
+      callbacks = cb
+      return vi.fn()
+    })
+    claimGlobalSideEffectMock.mockReturnValue(false)
+
+    renderHook(() => useGlobalEvents())
+
+    await waitFor(() => expect(callbacks).toBeDefined())
+
+    callbacks!.onPermissionAsked?.({
+      id: 'perm-background-claimed',
+      sessionID: 'background-session',
+      permission: 'bash',
+      patterns: [],
+    })
+
+    expect(activeSessionStoreMock.addPendingRequest).toHaveBeenCalledWith(
+      'perm-background-claimed',
+      'background-session',
+      'permission',
+      'bash',
+    )
+    expect(notificationPushMock).not.toHaveBeenCalled()
+  })
 })

--- a/src/hooks/useGlobalEvents.ts
+++ b/src/hooks/useGlobalEvents.ts
@@ -17,6 +17,7 @@ import { playNotificationSoundDeduped } from '../utils/notificationSoundBridge'
 import { subscribeToEvents, getSessionStatus, getPendingPermissions, getPendingQuestions } from '../api'
 import { replyPermission } from '../api/permission'
 import { autoApproveStore } from '../store/autoApproveStore'
+import { claimGlobalSideEffect } from '../utils/globalEventSideEffects'
 import type { ApiMessage, ApiPart, ApiPermissionRequest, ApiQuestionRequest } from '../api/types'
 import type { SessionStatusMap } from '../types/api/session'
 
@@ -120,6 +121,7 @@ const pendingQuestions = new Map<string, PendingRequest<ApiQuestionRequest>[]>()
 
 // 5秒后过期，防止内存泄漏
 const PENDING_TIMEOUT = 5000
+const AUTO_APPROVE_SIDE_EFFECT_TTL = 10000
 
 function cleanupExpired<T>(map: Map<string, PendingRequest<T>[]>) {
   const now = Date.now()
@@ -260,6 +262,33 @@ function isSessionDirectlyOpen(sessionId: string): boolean {
   return false
 }
 
+function runGlobalSideEffect(key: string, sideEffect: () => void) {
+  if (!claimGlobalSideEffect(key)) return
+  sideEffect()
+}
+
+function pushGlobalNotification(
+  key: string,
+  soundKey: string,
+  type: Parameters<typeof notificationStore.push>[0],
+  title: string,
+  body: string,
+  sessionId: string,
+  directory?: string,
+) {
+  runGlobalSideEffect(key, () => {
+    notificationStore.push(type, title, body, sessionId, directory, { soundKey })
+  })
+}
+
+function claimAutoApproveSideEffect(requestId: string): boolean {
+  if (!autoApproveStore.claimAutoReply(requestId)) return false
+  if (claimGlobalSideEffect(`auto-approve:${requestId}`, AUTO_APPROVE_SIDE_EFFECT_TTL)) return true
+
+  autoApproveStore.releaseAutoReply(requestId)
+  return false
+}
+
 export function useGlobalEvents(directories?: string[]) {
   const directoriesRef = useRef<string[] | undefined>(directories)
   const refreshRef = useRef<((strategy?: 'replace' | 'merge') => void) | null>(null)
@@ -323,7 +352,12 @@ export function useGlobalEvents(directories?: string[]) {
               ? !currentDirectories || currentDirectories.length === 0 || currentDirectories.includes(pending.directory)
               : pending.scopeKey === currentScopeKey
             if (!matchesScope) continue
-            activeSessionStore.addPendingRequest(pending.requestId, pending.sessionId, pending.type, pending.description)
+            activeSessionStore.addPendingRequest(
+              pending.requestId,
+              pending.sessionId,
+              pending.type,
+              pending.description,
+            )
           }
           activeSessionStore.setSessionMetaBulk(sessionMetaEntries)
         })
@@ -342,7 +376,8 @@ export function useGlobalEvents(directories?: string[]) {
     const approveGlobalPendingPermissions = () => {
       if (!autoApproveStore.approvePendingOnFullAuto || autoApproveStore.fullAutoMode !== 'global') return
 
-      const directoriesToFetch = directoriesRef.current && directoriesRef.current.length > 0 ? directoriesRef.current : [undefined]
+      const directoriesToFetch =
+        directoriesRef.current && directoriesRef.current.length > 0 ? directoriesRef.current : [undefined]
 
       void Promise.all(
         directoriesToFetch.map(async directory => {
@@ -350,7 +385,7 @@ export function useGlobalEvents(directories?: string[]) {
 
           await Promise.all(
             permissions.map(async request => {
-              if (!autoApproveStore.claimAutoReply(request.id)) return
+              if (!claimAutoApproveSideEffect(request.id)) return
 
               const dir = directory ?? activeSessionStore.getSessionMeta(request.sessionID)?.directory
               try {
@@ -442,9 +477,17 @@ export function useGlobalEvents(directories?: string[]) {
           if (!belongsToCurrentSession(error.sessionID)) {
             const meta = activeSessionStore.getSessionMeta(error.sessionID)
             const sessionLabel = meta?.title || error.sessionID.slice(0, 8)
-            notificationStore.push('error', sessionLabel, 'Session error', error.sessionID, meta?.directory)
+            pushGlobalNotification(
+              `notification:error:${error.sessionID}`,
+              `sound:error:${error.sessionID}`,
+              'error',
+              sessionLabel,
+              'Session error',
+              error.sessionID,
+              meta?.directory,
+            )
           } else if (isSessionDirectlyOpen(error.sessionID) && soundStore.getSnapshot().currentSessionEnabled) {
-            playNotificationSoundDeduped('error')
+            runGlobalSideEffect(`sound:error:${error.sessionID}`, () => playNotificationSoundDeduped('error'))
           }
         }
         dispatchToConsumers(error.sessionID, cb => cb.onSessionError?.(error.sessionID))
@@ -477,7 +520,7 @@ export function useGlobalEvents(directories?: string[]) {
         // Full Auto 全局模式拦截 — 所有会话的权限请求直接放行
         if (autoApproveStore.fullAutoMode === 'global') {
           const dir = activeSessionStore.getSessionMeta(request.sessionID)?.directory
-          if (autoApproveStore.claimAutoReply(request.id)) {
+          if (claimAutoApproveSideEffect(request.id)) {
             replyPermission(request.id, 'once', undefined, dir, request.sessionID).catch(() => {
               autoApproveStore.releaseAutoReply(request.id)
             })
@@ -504,10 +547,18 @@ export function useGlobalEvents(directories?: string[]) {
 
         // Toast 通知 — 不属于当前 session family 的才弹
         if (!belongsToCurrentSession(request.sessionID)) {
-          notificationStore.push('permission', `${sessionLabel} — Permission`, desc, request.sessionID, meta?.directory)
+          pushGlobalNotification(
+            `notification:permission:${request.id}`,
+            `sound:permission:${request.id}`,
+            'permission',
+            `${sessionLabel} — Permission`,
+            desc,
+            request.sessionID,
+            meta?.directory,
+          )
         } else if (isSessionDirectlyOpen(request.sessionID) && soundStore.getSnapshot().currentSessionEnabled) {
           // 当前会话：如果开启了当前会话提示音
-          playNotificationSoundDeduped('permission')
+          runGlobalSideEffect(`sound:permission:${request.id}`, () => playNotificationSoundDeduped('permission'))
         }
 
         if (belongsToCurrentSession(request.sessionID)) {
@@ -551,9 +602,17 @@ export function useGlobalEvents(directories?: string[]) {
 
         // Toast 通知
         if (!belongsToCurrentSession(request.sessionID)) {
-          notificationStore.push('question', `${sessionLabel} — Question`, desc, request.sessionID, meta?.directory)
+          pushGlobalNotification(
+            `notification:question:${request.id}`,
+            `sound:question:${request.id}`,
+            'question',
+            `${sessionLabel} — Question`,
+            desc,
+            request.sessionID,
+            meta?.directory,
+          )
         } else if (isSessionDirectlyOpen(request.sessionID) && soundStore.getSnapshot().currentSessionEnabled) {
-          playNotificationSoundDeduped('question')
+          runGlobalSideEffect(`sound:question:${request.id}`, () => playNotificationSoundDeduped('question'))
         }
 
         if (belongsToCurrentSession(request.sessionID)) {
@@ -597,14 +656,22 @@ export function useGlobalEvents(directories?: string[]) {
         if (wasBusy && data.status.type === 'idle' && !belongsToCurrentSession(data.sessionID)) {
           const meta = activeSessionStore.getSessionMeta(data.sessionID)
           const sessionLabel = meta?.title || data.sessionID.slice(0, 8)
-          notificationStore.push('completed', sessionLabel, 'Session completed', data.sessionID, meta?.directory)
+          pushGlobalNotification(
+            `notification:completed:${data.sessionID}`,
+            `sound:completed:${data.sessionID}`,
+            'completed',
+            sessionLabel,
+            'Session completed',
+            data.sessionID,
+            meta?.directory,
+          )
         } else if (
           wasBusy &&
           data.status.type === 'idle' &&
           isSessionDirectlyOpen(data.sessionID) &&
           soundStore.getSnapshot().currentSessionEnabled
         ) {
-          playNotificationSoundDeduped('completed')
+          runGlobalSideEffect(`sound:completed:${data.sessionID}`, () => playNotificationSoundDeduped('completed'))
         }
       },
 

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -17,7 +17,11 @@ import { useSyncExternalStore } from 'react'
 export type NotificationType = 'permission' | 'question' | 'completed' | 'error'
 
 /** push 后的回调，用于声音播放等扩展 */
-export type NotificationPushListener = (type: NotificationType) => void
+export interface NotificationPushOptions {
+  soundKey?: string
+}
+
+export type NotificationPushListener = (type: NotificationType, options?: NotificationPushOptions) => void
 
 export interface NotificationEntry {
   id: string
@@ -107,7 +111,9 @@ class NotificationStore {
   }
 
   private notify() {
-    this.subscribers.forEach(cb => cb())
+    this.subscribers.forEach(cb => {
+      cb()
+    })
   }
 
   private persist() {
@@ -137,7 +143,14 @@ class NotificationStore {
   // 推送通知（加历史 + 弹 toast）
   // ============================================
 
-  push(type: NotificationType, title: string, body: string, sessionId: string, directory?: string) {
+  push(
+    type: NotificationType,
+    title: string,
+    body: string,
+    sessionId: string,
+    directory?: string,
+    options?: NotificationPushOptions,
+  ) {
     const entry: NotificationEntry = {
       id: `notif_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
       type,
@@ -173,7 +186,7 @@ class NotificationStore {
     // 触发 push 后回调（声音播放等）
     this.pushListeners.forEach(fn => {
       try {
-        fn(type)
+        fn(type, options)
       } catch {
         // 回调异常不影响通知流程
       }
@@ -271,7 +284,9 @@ class NotificationStore {
   }
 
   dismissAllToasts() {
-    this.toastTimers.forEach(timer => clearTimeout(timer))
+    this.toastTimers.forEach(timer => {
+      clearTimeout(timer)
+    })
     this.toastTimers.clear()
     this.state = { ...this.state, toasts: [] }
     this.notify()

--- a/src/utils/globalEventSideEffects.test.ts
+++ b/src/utils/globalEventSideEffects.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { claimGlobalSideEffect } from './globalEventSideEffects'
+
+describe('claimGlobalSideEffect', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    localStorage.clear()
+  })
+
+  it('claims an unclaimed side effect and blocks duplicates during the ttl', () => {
+    expect(claimGlobalSideEffect('sound:permission:request-1', 1000)).toBe(true)
+    expect(claimGlobalSideEffect('sound:permission:request-1', 1000)).toBe(false)
+  })
+
+  it('allows a side effect again after the ttl expires', () => {
+    expect(claimGlobalSideEffect('notification:completed:session-1', 1000)).toBe(true)
+
+    vi.setSystemTime(new Date('2026-01-01T00:00:01.001Z'))
+
+    expect(claimGlobalSideEffect('notification:completed:session-1', 1000)).toBe(true)
+  })
+
+  it('removes the stored claim after the ttl when this instance still owns it', () => {
+    expect(claimGlobalSideEffect('notification:error:session-1', 1000)).toBe(true)
+    expect(localStorage.getItem('opencode:global-side-effect:notification:error:session-1')).not.toBeNull()
+
+    vi.advanceTimersByTime(1000)
+
+    expect(localStorage.getItem('opencode:global-side-effect:notification:error:session-1')).toBeNull()
+  })
+
+  it('does not let delayed cleanup remove a newer claim for the same key', () => {
+    expect(claimGlobalSideEffect('sound:completed:session-1', 1000)).toBe(true)
+
+    vi.setSystemTime(new Date('2026-01-01T00:00:01.001Z'))
+    expect(claimGlobalSideEffect('sound:completed:session-1', 5000)).toBe(true)
+
+    vi.advanceTimersByTime(1000)
+
+    expect(localStorage.getItem('opencode:global-side-effect:sound:completed:session-1')).not.toBeNull()
+  })
+
+  it('treats invalid stored data as unclaimed', () => {
+    localStorage.setItem('opencode:global-side-effect:sound:question:request-1', '{not-json')
+
+    expect(claimGlobalSideEffect('sound:question:request-1', 1000)).toBe(true)
+  })
+
+  it('preserves the side effect when localStorage is unavailable', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('storage unavailable')
+      },
+      setItem: () => {
+        throw new Error('storage unavailable')
+      },
+      removeItem: () => {
+        throw new Error('storage unavailable')
+      },
+      clear: () => undefined,
+    })
+
+    expect(claimGlobalSideEffect('sound:error:session-1', 1000)).toBe(true)
+  })
+})

--- a/src/utils/globalEventSideEffects.ts
+++ b/src/utils/globalEventSideEffects.ts
@@ -1,0 +1,78 @@
+// ============================================
+// Global Event Side Effects
+// ============================================
+//
+// Multiple app windows subscribe to the same global SSE stream. State updates
+// must still happen in every window, but one-shot side effects such as audio,
+// toasts, and automatic permission replies should only run once per event.
+
+interface SideEffectClaim {
+  token: string
+  expiresAt: number
+}
+
+const STORAGE_PREFIX = 'opencode:global-side-effect:'
+const DEFAULT_TTL_MS = 3000
+
+function createClaimToken(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+function parseClaim(raw: string | null): SideEffectClaim | null {
+  if (!raw) return null
+
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object') return null
+
+    const record = parsed as Record<string, unknown>
+    if (typeof record.token !== 'string') return null
+    if (typeof record.expiresAt !== 'number') return null
+    return { token: record.token, expiresAt: record.expiresAt }
+  } catch {
+    return null
+  }
+}
+
+function removeStoredClaim(storageKey: string, token: string) {
+  try {
+    const stored = parseClaim(localStorage.getItem(storageKey))
+    if (stored?.token === token) {
+      localStorage.removeItem(storageKey)
+    }
+  } catch {
+    // Ignore storage cleanup failures.
+  }
+}
+
+function scheduleClaimCleanup(storageKey: string, token: string, ttlMs: number) {
+  setTimeout(() => removeStoredClaim(storageKey, token), ttlMs)
+}
+
+export function claimGlobalSideEffect(key: string, ttlMs: number = DEFAULT_TTL_MS): boolean {
+  const storageKey = `${STORAGE_PREFIX}${key}`
+  const now = Date.now()
+
+  try {
+    const existing = parseClaim(localStorage.getItem(storageKey))
+    if (existing && existing.expiresAt > now) return false
+
+    const token = createClaimToken()
+    const claim: SideEffectClaim = {
+      token,
+      expiresAt: now + ttlMs,
+    }
+
+    localStorage.setItem(storageKey, JSON.stringify(claim))
+    const stored = parseClaim(localStorage.getItem(storageKey))
+    const claimed = stored?.token === token
+    if (claimed) {
+      scheduleClaimCleanup(storageKey, claim.token, ttlMs)
+    }
+    return claimed
+  } catch {
+    // If storage is unavailable, prefer preserving the side effect over
+    // dropping notifications/sounds entirely.
+    return true
+  }
+}

--- a/src/utils/notificationSoundBridge.test.ts
+++ b/src/utils/notificationSoundBridge.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NotificationPushListener } from '../store/notificationStore'
+
+const { claimGlobalSideEffectMock, getSoundSnapshotMock, getCustomAudioBlobMock, playSoundMock, onPushMock } =
+  vi.hoisted(() => ({
+    claimGlobalSideEffectMock: vi.fn(() => true),
+    getSoundSnapshotMock: vi.fn(() => ({
+      enabled: true,
+      volume: 0.5,
+      events: {
+        permission: { soundId: 'ding' },
+        question: { soundId: 'ding' },
+        completed: { soundId: 'ding' },
+        error: { soundId: 'ding' },
+      },
+    })),
+    getCustomAudioBlobMock: vi.fn(() => null),
+    playSoundMock: vi.fn(),
+    onPushMock: vi.fn(),
+  }))
+
+vi.mock('./globalEventSideEffects', () => ({
+  claimGlobalSideEffect: claimGlobalSideEffectMock,
+}))
+
+vi.mock('../store/notificationStore', () => ({
+  notificationStore: {
+    onPush: onPushMock,
+  },
+}))
+
+vi.mock('../store/soundStore', () => ({
+  soundStore: {
+    getSnapshot: () => getSoundSnapshotMock(),
+    getCustomAudioBlob: getCustomAudioBlobMock,
+  },
+}))
+
+vi.mock('./soundPlayer', () => ({
+  playSound: playSoundMock,
+}))
+
+describe('notificationSoundBridge', () => {
+  beforeEach(() => {
+    claimGlobalSideEffectMock.mockReset()
+    getSoundSnapshotMock.mockClear()
+    getCustomAudioBlobMock.mockClear()
+    playSoundMock.mockReset()
+    onPushMock.mockReset()
+    claimGlobalSideEffectMock.mockReturnValue(true)
+    getSoundSnapshotMock.mockReturnValue({
+      enabled: true,
+      volume: 0.5,
+      events: {
+        permission: { soundId: 'ding' },
+        question: { soundId: 'ding' },
+        completed: { soundId: 'ding' },
+        error: { soundId: 'ding' },
+      },
+    })
+  })
+
+  it('plays notification sound when the push sound key is claimed', async () => {
+    const { initNotificationSound } = await import('./notificationSoundBridge')
+    let listener: NotificationPushListener | undefined
+    onPushMock.mockImplementation(cb => {
+      listener = cb
+      return vi.fn()
+    })
+
+    initNotificationSound()
+
+    listener?.('permission', { soundKey: 'sound:permission:perm-1' })
+
+    expect(claimGlobalSideEffectMock).toHaveBeenCalledWith('sound:permission:perm-1')
+    expect(playSoundMock).toHaveBeenCalledWith({
+      soundId: 'ding',
+      customAudioData: null,
+      volume: 0.5,
+    })
+  })
+
+  it('skips notification sound when another window already claimed the same sound key', async () => {
+    const { initNotificationSound } = await import('./notificationSoundBridge')
+    let listener: NotificationPushListener | undefined
+    onPushMock.mockImplementation(cb => {
+      listener = cb
+      return vi.fn()
+    })
+    claimGlobalSideEffectMock.mockReturnValue(false)
+
+    initNotificationSound()
+
+    listener?.('permission', { soundKey: 'sound:permission:perm-1' })
+
+    expect(claimGlobalSideEffectMock).toHaveBeenCalledWith('sound:permission:perm-1')
+    expect(playSoundMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/notificationSoundBridge.ts
+++ b/src/utils/notificationSoundBridge.ts
@@ -14,6 +14,7 @@
 import type { NotificationType } from '../store/notificationStore'
 import { notificationStore } from '../store/notificationStore'
 import { soundStore } from '../store/soundStore'
+import { claimGlobalSideEffect } from './globalEventSideEffects'
 import { playSound } from './soundPlayer'
 
 /**
@@ -62,9 +63,10 @@ export function playNotificationSoundDeduped(type: NotificationType): void {
  * 在 App 层调用一次即可，注册 notificationStore.push 的声音回调
  */
 export function initNotificationSound(): () => void {
-  const unsubscribe = notificationStore.onPush((type: NotificationType) => {
+  const unsubscribe = notificationStore.onPush((type: NotificationType, options) => {
     // notificationStore.push 只在后台会话触发（非当前 session family）
     // 记录播放时间用于去重
+    if (options?.soundKey && !claimGlobalSideEffect(options.soundKey)) return
     recentPlays.set(type, Date.now())
     playNotificationSound(type)
   })


### PR DESCRIPTION
## 变更说明

修复多开 OpenCodeUI 窗口时，同一个全局事件可能在多个窗口重复触发一次性副作用的问题，重点包括通知声音、当前会话提示音、toast 以及部分全局自动批准路径。

这个分支的 6 个提交分两轮完成了同一条能力链路：

1. 先基于 `localStorage` TTL claim 建立跨窗口的全局副作用认领机制；
2. 再把通知声音和当前会话提示音进一步收敛到带 `Web Locks` 的锁定认领流程，降低竞态下的重复播放概率。

## 主要改动

### 1. 建立全局副作用认领基础设施
- 新增全局副作用认领工具，用 `localStorage` TTL claim 对一次性副作用做跨窗口 best-effort 去重。
- 覆盖过期、损坏存储、不可用存储和延迟清理等场景。

### 2. 让通知声音按事件级 key 去重
- 为 `notificationStore.push` 增加可选 `soundKey`。
- 后台通知声音复用事件级 key，避免多个窗口对同一事件重复播放提示音。
- 增补通知声音桥接测试，覆盖已被其他窗口认领时不重复播放的路径。

### 3. 将全局事件中的一次性副作用接入认领机制
- 将音频、toast、全局自动批准等一次性副作用接入跨窗口认领。
- 保留消息、会话状态和 pane consumer 的逐窗口更新，避免影响各窗口 UI 同步。
- 补充全局事件测试，覆盖当前会话与后台窗口混合分类时的重复音频场景。

### 4. 为声音认领增加 Web Locks 串行化
- 在原有 claim 机制上新增 `claimGlobalSideEffectLocked`。
- 优先通过 `Web Locks` 串行化同一 `soundKey` 的认领，避免多个窗口同时通过本地存储检查。
- 当 `Web Locks` 不可用或请求失败时，回退到带 token 确认延迟的 `localStorage` claim。

### 5. 将通知声音桥接改为“先认领，再播放”
- 新增 claimed sound bridge 播放入口。
- 通知声音在真正播放前先完成锁定认领。
- 让后台通知声音和当前会话声音共用同一套 `soundKey` 认领路径。

### 6. 将当前会话提示音统一接入声音桥接
- 将当前会话的 `error`、`permission`、`question`、`completed` 提示音交给通知声音桥接统一认领。
- 复用后台通知的 `soundKey`，避免同一事件在当前窗口和后台窗口重复响铃。
- 更新全局事件测试，断言桥接调用和共享认领 key 的行为。

## 验证

- LSP diagnostics: clean（本次修改涉及文件）
- Targeted tests passed:
  - `src/hooks/useGlobalEvents.test.tsx`
  - `src/utils/globalEventSideEffects.test.ts`
  - `src/utils/notificationSoundBridge.test.ts`

## 注意

该方案仍然是前端侧的跨窗口 best-effort 去重，不是严格分布式锁。

- `Web Locks` 可用时，会提供更强的同浏览器上下文串行化能力；
- `Web Locks` 不可用时，会回退到 `localStorage` claim；
- 当存储不可用时，仍保留副作用执行，避免漏掉通知或声音。