### PR TITLE
fix: mobile address bar issues in SettingsDialog and FileExplorer scrolling

### DIFF
--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -335,7 +335,7 @@ const FileTreeItem = memo(function FileTreeItem({
           text-text-300
           ${node.ignored ? 'opacity-50' : ''}
         `}
-        style={{ paddingLeft: `${depth * 12 + 8}px`, touchAction: 'none' }}
+        style={{ paddingLeft: `${depth * 12 + 8}px` }}
       >
         {/* Expand/Collapse Icon */}
         {isDirectory ? (

--- a/src/features/settings/SettingsDialog.tsx
+++ b/src/features/settings/SettingsDialog.tsx
@@ -262,7 +262,7 @@ export function SettingsDialog({ isOpen, onClose, initialTab = 'servers' }: Sett
         showCloseButton={false}
         rawContent
       >
-        <div className="flex flex-col" style={{ height: '92vh' }}>
+        <div className="flex flex-col" style={{ height: 'calc(var(--app-height) * 0.92)' }}>
           {/* Sticky Header + Tabs */}
           <div className="shrink-0">
             {/* Title bar */}


### PR DESCRIPTION
## Changes

### SettingsDialog
Replace `92vh` with `calc(var(--app-height) * 0.92)` on mobile layout. The `--app-height` CSS variable uses `100dvh` on supporting browsers, dynamically adjusting when the address bar shows/hides.

### FileExplorer
Remove `touchAction: "none"` from `FileTreeItem` buttons. This was added in ccb0280 to prevent browser interference with pointer-drag for @file-mention, but `startInternalDrag` already returns early for touch events (`if (event.pointerType === "touch") return`). The property silently broke touch scrolling on the file tree with no actual benefit on mobile.

## Impact
- Mobile: SettingsDialog now properly fits within the visible viewport; file tree touch scrolling now works
- Desktop: no change