### PR TITLE
feat: OMO system prompt 过滤功能

### DIFF
--- a/src/components/outlineIndexModel.ts
+++ b/src/components/outlineIndexModel.ts
@@ -1,5 +1,6 @@
 import type { Message } from '../types/message'
 import { getMessageText, hasRenderableParts, isAbortedMessage, isUserMessage } from '../types/message'
+import { detectOmoWrapper } from '../utils/omo'
 
 const FULL_TITLE_MAX = 80
 
@@ -33,7 +34,7 @@ export function buildOutlineSourceEntries(messages: Message[]): OutlineSourceEnt
   const entries: OutlineSourceEntry[] = []
   for (const msg of messages.filter(messageHasContent)) {
     if (!isUserMessage(msg.info)) continue
-    const raw =
+    let raw =
       msg.info.summary?.title?.trim() ||
       getMessageText(msg)
         .trim()
@@ -41,6 +42,13 @@ export function buildOutlineSourceEntries(messages: Message[]): OutlineSourceEnt
         .map(l => l.trim())
         .find(Boolean)
     if (!raw) continue
+    // 清理 OMO 包装
+    const wrapper = detectOmoWrapper(raw)
+    // 纯系统消息（无用户 prompt）直接跳过，不显示在指示条中
+    if (wrapper.isWrapped && !wrapper.userText) continue
+    if (wrapper.userText) {
+      raw = wrapper.userText
+    }
     const n = normalizeWhitespace(raw)
     entries.push({
       messageId: msg.info.id,

--- a/src/features/chat/input/useInputHistory.ts
+++ b/src/features/chat/input/useInputHistory.ts
@@ -1,6 +1,8 @@
-import { useRef, useMemo, useCallback, useEffect } from 'react'
+import { useRef, useMemo, useCallback, useEffect, useSyncExternalStore } from 'react'
+import { themeStore } from '../../../store/themeStore'
 import { useMessages } from '../../../store/messageStoreHooks'
 import { getMessageText, type FilePart, type AgentPart } from '../../../types/message'
+import { isOmoWrappedMessage } from '../../../utils/omo'
 import type { Attachment } from '../../attachment'
 
 // ============================================
@@ -38,6 +40,11 @@ interface UseInputHistoryReturn {
 export function useInputHistory({ textareaRef }: UseInputHistoryOptions): UseInputHistoryReturn {
   // 构建历史条目：从消息列表中提取去重的用户消息
   const messages = useMessages()
+  const omoInputHistorySimplify = useSyncExternalStore(
+    themeStore.subscribe,
+    () => themeStore.getSnapshot().omoInputHistorySimplify,
+    () => themeStore.getSnapshot().omoInputHistorySimplify,
+  )
   const userHistory = useMemo((): HistoryEntry[] => {
     const entries: HistoryEntry[] = []
     const seen = new Set<string>()
@@ -45,6 +52,7 @@ export function useInputHistory({ textareaRef }: UseInputHistoryOptions): UseInp
       if (msg.info.role !== 'user') continue
       const t = getMessageText(msg).trim()
       if (!t || seen.has(t)) continue
+      if (omoInputHistorySimplify && isOmoWrappedMessage(t)) continue
       seen.add(t)
 
       const atts: Attachment[] = []
@@ -93,7 +101,7 @@ export function useInputHistory({ textareaRef }: UseInputHistoryOptions): UseInp
       entries.push({ text: t, attachments: atts })
     }
     return entries
-  }, [messages])
+  }, [messages, omoInputHistorySimplify])
 
   // -1 = 未进入历史模式，0 = 最后一条，往上递增
   const historyIndexRef = useRef(-1)

--- a/src/features/message/MessageRenderer.tsx
+++ b/src/features/message/MessageRenderer.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useRef, useEffect, useLayoutEffect, useMemo, useCallback } from 'react'
+import { memo, useSyncExternalStore, useState, useRef, useEffect, useLayoutEffect, useMemo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { diffLines } from 'diff'
 import { animate } from 'motion/mini'
@@ -38,6 +38,8 @@ import type {
 } from '../../types/message'
 import { isToolPart, isVisibleReasoningPart, isVisibleTextPart } from '../../types/message'
 import { formatDuration, formatCompletedAt, formatDetailedDateTime } from '../../utils/formatUtils'
+import { themeStore } from '../../store/themeStore'
+import { detectOmoWrapper } from '../../utils/omo'
 
 interface MessageRendererProps {
   message: Message
@@ -262,6 +264,12 @@ const UserMessageView = memo(function UserMessageView({
   const [showSystemContext, setShowSystemContext] = useState(false)
   const shouldRenderSystemContext = useDelayedRender(showSystemContext)
   const { collapseUserMessages } = useTheme()
+  // 精简 OMO 历史指令开关 — 同时控制消息正文中的 OMO 过滤
+  const omoInputHistorySimplify = useSyncExternalStore(
+    themeStore.subscribe,
+    () => themeStore.getSnapshot().omoInputHistorySimplify,
+    () => themeStore.getSnapshot().omoInputHistorySimplify,
+  )
 
   const wrapperRef = useEntryGrowAnimation(info.time.created)
 
@@ -275,12 +283,102 @@ const UserMessageView = memo(function UserMessageView({
   const hasSystemContext = syntheticParts.length > 0
   const messageText = textParts.map(p => p.text).join('')
 
+  // OMO 包装检测与提取（受开关控制）
+  const omoWrapper = useMemo(() => {
+    if (!messageText || !omoInputHistorySimplify) return null
+    return detectOmoWrapper(messageText)
+  }, [messageText, omoInputHistorySimplify])
+  const [showOmoWrapper, setShowOmoWrapper] = useState(false)
+  const shouldRenderOmoWrapper = useDelayedRender(showOmoWrapper)
+  const displayText = omoWrapper?.isWrapped && omoWrapper.userText ? omoWrapper.userText : messageText
+
   return (
     <div ref={wrapperRef} className="flex flex-col items-end group">
       <div className="flex flex-col gap-1 items-end w-full">
         {/* 消息文本 */}
-        {messageText && (
-          <CollapsibleUserText text={messageText} collapseEnabled={collapseUserMessages} messageId={info.id} />
+        {displayText && !(omoWrapper?.isWrapped && !omoWrapper.userText) && (
+          <div className="flex flex-col items-end gap-1">
+            {/* OMO 标签 */}
+            {omoWrapper?.isWrapped && omoWrapper.labels.length > 0 && (
+              <div className="flex items-center gap-1">
+                {omoWrapper.labels.map(label => (
+                  <span
+                    key={label}
+                    className="inline-block px-2 py-0.5 rounded-md text-[length:var(--fs-xs)] font-medium bg-accent-secondary-100/15 text-accent-secondary-100"
+                  >
+                    {label}
+                  </span>
+                ))}
+              </div>
+            )}
+            <CollapsibleUserText text={displayText} collapseEnabled={collapseUserMessages} messageId={info.id} />
+            {/* 查看完整包装内容按钮 */}
+            {omoWrapper?.isWrapped && messageText !== displayText && (
+              <div className="flex flex-col items-end mt-1">
+                <button
+                  onClick={() => setShowOmoWrapper(!showOmoWrapper)}
+                  className="flex items-center gap-1 text-[length:var(--fs-sm)] text-text-400 hover:text-text-300 transition-colors py-1 px-2 rounded hover:bg-bg-200"
+                >
+                  <span>{showOmoWrapper ? t('hideSystemContext') : t('showSystemContext', { count: 1 })}</span>
+                  <span className={`transition-transform duration-300 ${showOmoWrapper ? '' : '-rotate-90'}`}>
+                    <ChevronDownIcon size={10} />
+                  </span>
+                </button>
+                <div
+                  className={`grid w-full transition-[grid-template-rows,opacity] duration-300 ease-out ${
+                    showOmoWrapper ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
+                  }`}
+                >
+                  <div className="overflow-hidden">
+                    {shouldRenderOmoWrapper && (
+                      <div className="pt-1 px-4 py-2.5 bg-bg-300/50 rounded-2xl max-w-full">
+                        <p className="m-0 whitespace-pre-wrap break-words text-[length:var(--fs-xs)] text-text-400 leading-relaxed">
+                          {messageText}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+        {/* 纯系统消息（有包装但无用户文本）：仅显示标签 + 小展开按钮 */}
+        {omoWrapper?.isWrapped && !omoWrapper.userText && omoWrapper.labels.length > 0 && (
+          <div className="flex items-center gap-2">
+            {omoWrapper.labels.map(label => (
+              <span
+                key={label}
+                className="inline-block px-2 py-0.5 rounded-md text-[length:var(--fs-xs)] font-medium bg-accent-secondary-100/15 text-accent-secondary-100"
+              >
+                {label}
+              </span>
+            ))}
+            <button
+              onClick={() => setShowOmoWrapper(!showOmoWrapper)}
+              className="flex items-center gap-1 text-[length:var(--fs-xs)] text-text-400 hover:text-text-300 transition-colors"
+            >
+              <ChevronDownIcon
+                size={10}
+                className={`transition-transform duration-200 ${showOmoWrapper ? 'rotate-0' : '-rotate-90'}`}
+              />
+            </button>
+            <div
+              className={`grid transition-[grid-template-rows,opacity] duration-300 ease-out ${
+                showOmoWrapper ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
+              }`}
+            >
+              <div className="overflow-hidden">
+                {shouldRenderOmoWrapper && (
+                  <div className="pt-1 px-4 py-2.5 bg-bg-300/50 rounded-2xl max-w-full">
+                    <p className="m-0 whitespace-pre-wrap break-words text-[length:var(--fs-xs)] text-text-400 leading-relaxed">
+                      {messageText}
+                    </p>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
         )}
 
         {/* 用户附件 */}
@@ -350,7 +448,7 @@ const UserMessageView = memo(function UserMessageView({
           )}
           <ForkActionButton message={message} onFork={onFork} forkMessageId={forkMessageId} />
           {/* Copy button */}
-          {messageText && <CopyButton text={messageText} position="static" />}
+          {displayText && <CopyButton text={displayText} position="static" />}
         </div>
       </div>
     </div>

--- a/src/features/settings/components/ChatSettings.tsx
+++ b/src/features/settings/components/ChatSettings.tsx
@@ -11,6 +11,7 @@ export function ChatSettings() {
   const { pathMode, setPathMode, effectiveStyle, detectedStyle, isAutoMode } = usePathMode()
   const { externalFileDropMode, setExternalFileDropMode } = useTheme()
   const [collapseUserMessages, setCollapseUserMessages] = useState(themeStore.collapseUserMessages)
+  const [omoInputHistorySimplify, setOmoInputHistorySimplify] = useState(themeStore.omoInputHistorySimplify)
   const [stepFinishDisplay, setStepFinishDisplay] = useState(themeStore.stepFinishDisplay)
   const [completedAtFormat, setCompletedAtFormat] = useState(themeStore.completedAtFormat)
   const [reasoningDisplayMode, setReasoningDisplayMode] = useState(themeStore.reasoningDisplayMode)
@@ -21,6 +22,12 @@ export function ChatSettings() {
     const v = !collapseUserMessages
     setCollapseUserMessages(v)
     themeStore.setCollapseUserMessages(v)
+  }
+
+  const handleOmoInputHistorySimplifyToggle = () => {
+    const v = !omoInputHistorySimplify
+    setOmoInputHistorySimplify(v)
+    themeStore.setOmoInputHistorySimplify(v)
   }
 
   const handleReasoningDisplayModeChange = (mode: ReasoningDisplayMode) => {
@@ -75,6 +82,14 @@ export function ChatSettings() {
           onClick={handleCollapseToggle}
         >
           <Toggle enabled={collapseUserMessages} onChange={handleCollapseToggle} />
+        </SettingRow>
+
+        <SettingRow
+          label={t('chat.omoInputHistorySimplify')}
+          description={t('chat.omoInputHistorySimplifyDesc')}
+          onClick={handleOmoInputHistorySimplifyToggle}
+        >
+          <Toggle enabled={omoInputHistorySimplify} onChange={handleOmoInputHistorySimplifyToggle} />
         </SettingRow>
 
         <div>

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -90,6 +90,8 @@
     "conversationExperienceDesc": "Message density, reasoning style, and step summary fields",
     "collapseLongMessages": "Collapse Long Messages",
     "collapseLongMessagesDesc": "Auto-collapse lengthy user messages",
+    "omoInputHistorySimplify": "Simplify OMO History",
+    "omoInputHistorySimplifyDesc": "Filter out OMO internal marker messages from input history navigation",
     "descriptiveToolSteps": "Descriptive Steps",
     "descriptiveToolStepsDesc": "Replace plain step counts with tool-aware summaries and show a steps line even for single tool calls",
     "inlineToolRequests": "Inline Tool Requests",

--- a/src/locales/zh-CN/settings.json
+++ b/src/locales/zh-CN/settings.json
@@ -90,6 +90,8 @@
     "conversationExperienceDesc": "消息密度、推理风格和步骤摘要字段",
     "collapseLongMessages": "折叠长消息",
     "collapseLongMessagesDesc": "自动折叠较长的用户消息",
+    "omoInputHistorySimplify": "精简 OMO 历史指令",
+    "omoInputHistorySimplifyDesc": "输入历史导航中过滤带有 OMO 内部标记的指令消息",
     "descriptiveToolSteps": "描述型步骤",
     "descriptiveToolStepsDesc": "把普通 steps 计数改成带工具描述的摘要，并让单工具调用也显示步骤描述",
     "inlineToolRequests": "工具内嵌请求",

--- a/src/store/themeStore.ts
+++ b/src/store/themeStore.ts
@@ -115,6 +115,7 @@ const DEFAULT_INLINE_TOOL_REQUESTS = false
 const DEFAULT_CODE_WORD_WRAP = false
 const DEFAULT_UI_FONT_SCALE = 0
 const DEFAULT_CODE_FONT_SCALE = 0
+const DEFAULT_OMO_INPUT_HISTORY_SIMPLIFY = false
 
 /** 工具输出渲染风格：classic = 经典（input+output 分离），compact = 精简（只展示 output，header 更矮） */
 export type ToolCardStyle = 'classic' | 'compact'
@@ -139,6 +140,8 @@ export interface ThemeState {
   activeCustomCSSSnippetId: string | null
   /** 是否自动折叠长用户消息 */
   collapseUserMessages: boolean
+  /** 是否精简 omo 历史指令提示 */
+  omoInputHistorySimplify: boolean
   /** step-finish 信息栏显示开关 */
   stepFinishDisplay: StepFinishDisplay
   /** 完成时刻显示格式 */
@@ -187,6 +190,7 @@ const STORAGE_KEY_CUSTOM_CSS = 'theme-custom-css'
 const STORAGE_KEY_CUSTOM_CSS_SNIPPETS = 'theme-custom-css-snippets'
 const STORAGE_KEY_ACTIVE_CUSTOM_CSS_SNIPPET_ID = 'theme-active-custom-css-snippet-id'
 const STORAGE_KEY_COLLAPSE_USER_MESSAGES = 'collapse-user-messages'
+const STORAGE_KEY_OMO_INPUT_HISTORY_SIMPLIFY = 'omo-input-history-simplify'
 const STORAGE_KEY_STEP_FINISH_DISPLAY = 'step-finish-display'
 const STORAGE_KEY_COMPLETED_AT_FORMAT = 'completed-at-format'
 const STORAGE_KEY_REASONING_DISPLAY_MODE = 'reasoning-display-mode'
@@ -254,6 +258,7 @@ class ThemeStore {
       : null
     const savedCollapse = localStorage.getItem(STORAGE_KEY_COLLAPSE_USER_MESSAGES)
     const collapseUserMessages = savedCollapse === null ? true : savedCollapse === 'true'
+    const omoInputHistorySimplify = localStorage.getItem(STORAGE_KEY_OMO_INPUT_HISTORY_SIMPLIFY) === 'true'
     const savedReasoningDisplay = localStorage.getItem(STORAGE_KEY_REASONING_DISPLAY_MODE)
     const reasoningDisplayMode: ReasoningDisplayMode =
       savedReasoningDisplay === 'italic' || savedReasoningDisplay === 'markdown'
@@ -331,6 +336,7 @@ class ThemeStore {
       customCSSSnippets,
       activeCustomCSSSnippetId,
       collapseUserMessages,
+      omoInputHistorySimplify,
       stepFinishDisplay,
       completedAtFormat,
       reasoningDisplayMode,
@@ -374,6 +380,9 @@ class ThemeStore {
   }
   get collapseUserMessages() {
     return this.state.collapseUserMessages
+  }
+  get omoInputHistorySimplify() {
+    return this.state.omoInputHistorySimplify
   }
   get stepFinishDisplay() {
     return this.state.stepFinishDisplay
@@ -550,6 +559,13 @@ class ThemeStore {
     if (this.state.collapseUserMessages === enabled) return
     this.state = { ...this.state, collapseUserMessages: enabled }
     localStorage.setItem(STORAGE_KEY_COLLAPSE_USER_MESSAGES, String(enabled))
+    this.emit()
+  }
+
+  setOmoInputHistorySimplify(enabled: boolean) {
+    if (this.state.omoInputHistorySimplify === enabled) return
+    this.state = { ...this.state, omoInputHistorySimplify: enabled }
+    localStorage.setItem(STORAGE_KEY_OMO_INPUT_HISTORY_SIMPLIFY, String(enabled))
     this.emit()
   }
 
@@ -895,6 +911,10 @@ function normalizeThemeBackup(raw: unknown): ThemeBackup {
     customCSSSnippets,
     activeCustomCSSSnippetId,
     collapseUserMessages: typeof parsed?.collapseUserMessages === 'boolean' ? parsed.collapseUserMessages : true,
+    omoInputHistorySimplify:
+      typeof parsed?.omoInputHistorySimplify === 'boolean'
+        ? parsed.omoInputHistorySimplify
+        : DEFAULT_OMO_INPUT_HISTORY_SIMPLIFY,
     stepFinishDisplay:
       parsed?.stepFinishDisplay && typeof parsed.stepFinishDisplay === 'object'
         ? { ...DEFAULT_STEP_FINISH_DISPLAY, ...(parsed.stepFinishDisplay as Partial<StepFinishDisplay>) }
@@ -958,6 +978,7 @@ export function importThemeBackup(raw: unknown): void {
     localStorage.removeItem(STORAGE_KEY_ACTIVE_CUSTOM_CSS_SNIPPET_ID)
   }
   localStorage.setItem(STORAGE_KEY_COLLAPSE_USER_MESSAGES, String(backup.collapseUserMessages))
+  localStorage.setItem(STORAGE_KEY_OMO_INPUT_HISTORY_SIMPLIFY, String(backup.omoInputHistorySimplify))
   localStorage.setItem(STORAGE_KEY_STEP_FINISH_DISPLAY, JSON.stringify(backup.stepFinishDisplay))
   localStorage.setItem(STORAGE_KEY_COMPLETED_AT_FORMAT, backup.completedAtFormat)
   localStorage.setItem(STORAGE_KEY_REASONING_DISPLAY_MODE, backup.reasoningDisplayMode)

--- a/src/utils/omo.ts
+++ b/src/utils/omo.ts
@@ -1,0 +1,327 @@
+const OMO_INTERNAL_INITIATOR_MARKER_PATTERN = /<!--\s*OMO_INTERNAL_INITIATOR\s*-->/
+const SYSTEM_REMINDER_OPEN_TAG = '<system-reminder>'
+const SYSTEM_REMINDER_CLOSE_TAG = '</system-reminder>'
+const SYSTEM_DIRECTIVE_PATTERN = /\[SYSTEM DIRECTIVE:[^\]]*\]/
+const USER_REQUEST_OPEN_TAG = '<user-request>'
+const USER_REQUEST_CLOSE_TAG = '</user-request>'
+const USER_TASK_OPEN_TAG = '<user-task>'
+const USER_TASK_CLOSE_TAG = '</user-task>'
+const AUTO_SLASH_COMMAND_OPEN_TAG = '<auto-slash-command>'
+const AUTO_SLASH_COMMAND_CLOSE_TAG = '</auto-slash-command>'
+const ULTRAWORK_MODE_OPEN_TAG = '<ultrawork-mode>'
+const ULTRAWORK_MODE_CLOSE_TAG = '</ultrawork-mode>'
+const USER_REQUEST_HEADING = '## User Request'
+const USER_ARGUMENTS_PREFIX = '**User Arguments**:'
+const OMO_MODE_PROMPT_MARKERS = ['[search-mode]', '[analyze-mode]'] as const
+/** 裸 ulw 前缀（非 XML 标签形式，用户直接输入 "ulw ..."） */
+const BARE_ULW_PATTERN = /^ulw\b\s*/
+
+interface TaggedContent {
+  content: string
+  closeIndex: number
+}
+
+export type OmoModePromptMarker = (typeof OMO_MODE_PROMPT_MARKERS)[number]
+
+export function hasOmoInternalInitiatorMarker(rawText: string): boolean {
+  return OMO_INTERNAL_INITIATOR_MARKER_PATTERN.test(rawText.normalize('NFC'))
+}
+
+/** 检测结果类型 */
+export interface OmoWrapperResult {
+  /** 是否被 OMO 包装 */
+  isWrapped: boolean
+  /** 分类标签列表，如 ['ulw', 'search-mode'] */
+  labels: string[]
+  /** 提取出的真实用户 prompt */
+  userText: string | undefined
+  /** 原始包装内容（用于展开查看） */
+  rawWrapper: string | undefined
+}
+
+/**
+ * 统一检测 OMO 包装消息——支持多标签。
+ * 收集所有匹配的 system 级别标记，然后提取真实用户文本。
+ */
+export function detectOmoWrapper(rawText: string): OmoWrapperResult {
+  const source = rawText.normalize('NFC').trimStart()
+  if (!source) return { isWrapped: false, labels: [], userText: undefined, rawWrapper: undefined }
+
+  const labels: string[] = []
+  let userText: string | undefined
+  let rawWrapper: string | undefined
+
+  // ── Phase 1: 收集所有 user-oriented 标记 ──
+  // 扫描所有 mode markers（一个消息可能同时有 [search-mode] 和 [analyze-mode]）
+  for (const marker of OMO_MODE_PROMPT_MARKERS) {
+    if (source.includes(marker)) {
+      const label = marker.replace(/\[|\]/g, '')
+      if (!labels.includes(label)) labels.push(label)
+    }
+  }
+
+  // 预先提取 mode marker 后的 body，用于在其中继续扫描额外标记
+  // 先剥离可能的 OMO comment 前缀
+  let modeBody = hasOmoInternalInitiatorMarker(source)
+    ? source.replace(OMO_INTERNAL_INITIATOR_MARKER_PATTERN, '').trimStart()
+    : source
+  const firstMarker = findOmoModePromptMarker(modeBody)
+  if (firstMarker) {
+    const body = extractOmoModePromptBody(modeBody)
+    if (body) modeBody = body
+  }
+
+  // 在 body 中查找 ulw
+  if (BARE_ULW_PATTERN.test(modeBody) && !labels.includes('ulw')) {
+    labels.push('ulw')
+  }
+
+  // 在 body 中检查 ultrawork-mode XML（可能在 body 开头或内部）
+  if ((modeBody.startsWith(ULTRAWORK_MODE_OPEN_TAG) || source.includes(ULTRAWORK_MODE_OPEN_TAG)) && !labels.includes('ulw')) {
+    labels.push('ulw')
+  }
+
+  // ── Phase 2: userText 提取（按优先级应用 stripper） ──
+  if (labels.length > 0) {
+    let working = source
+
+    // 2a. 剥离 OMO comment 前缀（如果存在），否则后续 stripper 找不到位于其后的 marker
+    if (hasOmoInternalInitiatorMarker(working)) {
+      working = working.replace(OMO_INTERNAL_INITIATOR_MARKER_PATTERN, '').trimStart()
+    }
+
+    // 2b. 剥离 mode marker 前缀（根据 labels 判断，而非 firstMarker）
+    const hasModeLabel = labels.some(l => l === 'search-mode' || l === 'analyze-mode')
+    if (hasModeLabel) {
+      const body = extractOmoModePromptBody(working)
+      working = body ?? working
+    }
+
+    // 2c. 剥离裸 ulw
+    const ulwMatch = working.match(BARE_ULW_PATTERN)
+    if (ulwMatch) {
+      working = working.slice(ulwMatch[0].length).trim()
+    }
+
+    // 2d. 剥离 ultrawork-mode XML
+    const uwTrailing = extractOmoUltraworkTrailingUserText(working)
+    if (uwTrailing !== undefined) {
+      working = uwTrailing
+    }
+
+    // 2e. 兜底正则剥离：移除已知的 [search-mode] / [analyze-mode] / <ultrawork-mode> 文本块
+    //     作为保底，即使前面的逻辑未完全清理也能生效
+    working = stripKnownOmoBlocks(working)
+
+    userText = working || undefined
+    rawWrapper = source
+  }
+
+  // ── Phase 3: 仅无 user label 时检查 system-only 包装 ──
+  if (labels.length === 0) {
+    // system-reminder
+    const sr = extractLastTaggedContent(source, SYSTEM_REMINDER_OPEN_TAG, SYSTEM_REMINDER_CLOSE_TAG)
+    if (sr) {
+      labels.push('system-reminder')
+      let trailing = source.slice(sr.closeIndex + SYSTEM_REMINDER_CLOSE_TAG.length).trim()
+      // 剥离尾部可能跟随的 OMO_INTERNAL_INITIATOR 标记
+      trailing = trailing.replace(OMO_INTERNAL_INITIATOR_MARKER_PATTERN, '').trim()
+      userText = trailing || undefined
+      rawWrapper = sr.content
+    }
+  }
+
+  // OMO_INTERNAL_INITIATOR（提到 SYSTEM DIRECTIVE 之前，更好地处理纯系统消息）
+  if (labels.length === 0) {
+    if (hasOmoInternalInitiatorMarker(source)) {
+      labels.push('omo')
+      // 先尝试提取包装的用户文本
+      const wrapped = extractOmoWrappedUserText(source)
+      if (wrapped) {
+        userText = wrapped
+        rawWrapper = source
+      } else {
+        // 剥离 OMO 标记后保留剩余文本（用户可能引用提及 OMO 标记本身）
+        const stripped = source.replace(OMO_INTERNAL_INITIATOR_MARKER_PATTERN, '').trimStart()
+        const innerUlw = stripped.match(BARE_ULW_PATTERN)
+        if (innerUlw) {
+          userText = stripped.slice(innerUlw[0].length).trim() || undefined
+        } else if (stripped) {
+          userText = stripped
+        }
+        // stripped 为空 → userText 保持 undefined（纯标记消息）
+        rawWrapper = source
+      }
+    }
+  }
+
+  if (labels.length === 0) {
+    const dm = source.match(SYSTEM_DIRECTIVE_PATTERN)
+    if (dm) {
+      labels.push('system-directive')
+      userText = source.slice(dm.index! + dm[0].length).trim() || undefined
+      rawWrapper = dm[0]
+    }
+  }
+
+  if (labels.length === 0) {
+    const wrappedUserText = extractOmoWrappedUserText(source)
+    if (wrappedUserText) {
+      labels.push('omo')
+      userText = wrappedUserText
+      rawWrapper = source
+    }
+  }
+
+  // ── 最终兜底：对 userText 做正则清理（覆盖 Phase 2 和 Phase 3 的所有结果） ──
+  if (userText) {
+    userText = stripKnownOmoBlocks(userText) || undefined
+  }
+
+  return { isWrapped: labels.length > 0, labels, userText, rawWrapper }
+}
+
+/** 判断是否是被 OMO 包装的消息（用于过滤） */
+export function isOmoWrappedMessage(rawText: string): boolean {
+  return detectOmoWrapper(rawText).isWrapped
+}
+
+/** 提取 OMO 包装后的真实用户文本（用于显示） */
+export function extractOmoUserText(rawText: string): string | undefined {
+  return detectOmoWrapper(rawText).userText
+}
+
+/** 提取 OMO 标签列表（用于显示标签） */
+export function extractOmoLabels(rawText: string): string[] {
+  return detectOmoWrapper(rawText).labels
+}
+
+export function extractOmoLastUserRequest(rawText: string): string | undefined {
+  return extractLastTaggedContent(rawText.normalize('NFC'), USER_REQUEST_OPEN_TAG, USER_REQUEST_CLOSE_TAG)?.content
+}
+
+export function extractOmoLastUserTask(rawText: string): string | undefined {
+  return extractLastTaggedContent(rawText.normalize('NFC'), USER_TASK_OPEN_TAG, USER_TASK_CLOSE_TAG)?.content
+}
+
+export function extractOmoWrappedUserText(rawText: string): string | undefined {
+  const source = rawText.normalize('NFC')
+  const userRequest = extractLastTaggedContent(source, USER_REQUEST_OPEN_TAG, USER_REQUEST_CLOSE_TAG)
+  const userTask = extractLastTaggedContent(source, USER_TASK_OPEN_TAG, USER_TASK_CLOSE_TAG)
+  const taggedUserText = [userRequest, userTask]
+    .filter((content): content is TaggedContent => content !== undefined)
+    .sort((a, b) => b.closeIndex - a.closeIndex)[0]
+  if (taggedUserText) return taggedUserText.content
+
+  const autoSlashCommand = extractLastTaggedContent(source, AUTO_SLASH_COMMAND_OPEN_TAG, AUTO_SLASH_COMMAND_CLOSE_TAG)
+  if (!autoSlashCommand) return undefined
+  return extractMarkdownUserRequest(autoSlashCommand.content) ?? extractUserArguments(autoSlashCommand.content)
+}
+
+export function findOmoModePromptMarker(rawText: string): OmoModePromptMarker | undefined {
+  const trimmedStart = rawText.normalize('NFC').trimStart()
+  return OMO_MODE_PROMPT_MARKERS.find(marker => trimmedStart.startsWith(marker))
+}
+
+export function extractOmoModePromptBody(rawText: string): string | undefined {
+  const source = rawText.normalize('NFC')
+  const trimmedStart = source.trimStart()
+  const marker = findOmoModePromptMarker(trimmedStart)
+  if (!marker) return undefined
+
+  const wrappedUserText = extractOmoWrappedUserText(trimmedStart)
+  if (wrappedUserText) return wrappedUserText
+
+  const lines = trimmedStart.split(/\r?\n/)
+  let separatorIndex = -1
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === '---') separatorIndex = i
+  }
+
+  const body = separatorIndex >= 0 ? lines.slice(separatorIndex + 1).join('\n') : trimmedStart.slice(marker.length)
+  const cleaned = body.trim()
+  return cleaned || undefined
+}
+
+export function extractOmoUltraworkTrailingUserText(rawText: string): string | undefined {
+  const trimmedStart = rawText.normalize('NFC').trimStart()
+  if (!trimmedStart.startsWith(ULTRAWORK_MODE_OPEN_TAG)) return undefined
+
+  const closeIndex = trimmedStart.indexOf(ULTRAWORK_MODE_CLOSE_TAG)
+  if (closeIndex === -1) return undefined
+
+  const trailing = trimmedStart.slice(closeIndex + ULTRAWORK_MODE_CLOSE_TAG.length).trim()
+  if (!trailing) return undefined
+
+  const cleaned = trailing.replace(/^(?:---\s*(?:\r?\n|$))+/, '').trim()
+  return cleaned || undefined
+}
+
+/** 兜底正则剥离：移除 [search-mode] / [analyze-mode] / <ultrawork-mode> 的已知固定提示词文本块 */
+function stripKnownOmoBlocks(rawText: string): string {
+  let text = rawText
+
+  // [search-mode] 文本块：从 [search-mode]\n 到下一个 [xxx] / <xxx> / --- / OMO 标记 / 字符串末尾
+  text = text.replace(
+    /\[search-mode\]\s*\n[\s\S]*?(?=\[analyze-mode\]|\[search-mode\]|<ultrawork|<system-reminder>|---\s*\n|<!-- OMO|$)/g,
+    '',
+  )
+
+  // [analyze-mode] 文本块：同上
+  text = text.replace(
+    /\[analyze-mode\]\s*\n[\s\S]*?(?=\[search-mode\]|\[analyze-mode\]|<ultrawork|<system-reminder>|---\s*\n|<!-- OMO|$)/g,
+    '',
+  )
+
+  // <ultrawork-mode>...</ultrawork-mode> 文本块
+  text = text.replace(/<ultrawork-mode>[\s\S]*?<\/ultrawork-mode>/g, '')
+
+  // OMO delegate_task 标准指令行（出现在 --- 分隔之后，逐行剥离）
+  text = text.replace(/^MANDATORY delegate_task[^\n]*\n?/gm, '')
+  text = text.replace(/^Example: delegate_task[^\n]*\n?/gm, '')
+
+  // 清理残留的 --- 分隔线
+  text = text.replace(/^---\s*\n/gm, '')
+
+  return text.trim()
+}
+
+function extractLastTaggedContent(rawText: string, openTag: string, closeTag: string): TaggedContent | undefined {
+  let closeIndex = rawText.lastIndexOf(closeTag)
+
+  while (closeIndex !== -1) {
+    const openIndex = rawText.lastIndexOf(openTag, closeIndex)
+    if (openIndex === -1) return undefined
+
+    const contentStart = openIndex + openTag.length
+    const content = rawText.slice(contentStart, closeIndex).trim()
+    if (content) return { content, closeIndex }
+
+    closeIndex = rawText.lastIndexOf(closeTag, openIndex - 1)
+  }
+
+  return undefined
+}
+
+function extractMarkdownUserRequest(rawText: string): string | undefined {
+  const lines = rawText.normalize('NFC').split(/\r?\n/)
+  let headingIndex = -1
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === USER_REQUEST_HEADING) headingIndex = i
+  }
+  if (headingIndex === -1) return undefined
+
+  const content = lines.slice(headingIndex + 1).join('\n').trim()
+  return content || undefined
+}
+
+function extractUserArguments(rawText: string): string | undefined {
+  const lines = rawText.normalize('NFC').split(/\r?\n/)
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim()
+    if (!line.startsWith(USER_ARGUMENTS_PREFIX)) continue
+    const content = line.slice(USER_ARGUMENTS_PREFIX.length).trim()
+    return content || undefined
+  }
+  return undefined
+}


### PR DESCRIPTION
该功能主要用于适配opencode插件 [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent)。

*该功能部分参考了 @MiunaQwQ 在 [MiunaQwQ/OpenCodeUI](https://github.com/MiunaQwQ/OpenCodeUI) 中的实现。*

### 效果
通过设置/对话页的 精简OMO指令 开关来启用该功能。启用后，将检测omo的system prompt，分类为标签显示后将原始system prompt隐藏，在用户对话界面默认只显示标签与用户输入的提示词。支持多标签同时识别显示。

### 实现逻辑
检测入口 detectOmoWrapper(rawText) → { isWrapped, labels, userText, rawWrapper }

**三阶段：**
- 收集标签 — 扫描全部 [search-mode]/[analyze-mode]（用 includes 兜底 OMO 注释前缀）、body 中的裸 ulw、<ultrawork-mode> XML
- 文本提取 — 按序剥离 OMO 注释 → mode marker → ulw → ultrawork-mode，末位正则兜底移除已知 prompt 块内容
- 系统消息兜底 — 无 user label 时检测 <system-reminder>（同时剥离尾部 OMO 标记）、OMO_INTERNAL_INITIATOR（剥离标记后保留剩余文本防误杀用户提及）、[SYSTEM DIRECTIVE]

**生效层面：**
- 对话正文 — 显示标签 badges + 清洗后文本，纯系统消息仅显示标签+展开按钮
- 输入历史 — 设置开关控制过滤

### 测试
暂未发现与当前前端其他功能冲突。