### PR TITLE
fix: improve streaming render performance under heavy usage

### DIFF
--- a/src/features/chat/ChatArea.tsx
+++ b/src/features/chat/ChatArea.tsx
@@ -177,6 +177,9 @@ export const ChatArea = memo(
       const pendingScrollClearTimerRef = useRef<number | null>(null)
       const pendingAnchorClearRafRef = useRef<number | null>(null)
       const pendingSessionResetRafRef = useRef<number | null>(null)
+      // rAF 批处理高度更新：同帧内多次 ResizeObserver 回调合并为一次 setState
+      const pendingHeightUpdatesRef = useRef<Map<string, number>>(new Map())
+      const heightFlushRafRef = useRef<number | null>(null)
       const lastScrollRootSizeRef = useRef({ width: 0, height: 0 })
       const previousActivePagesRef = useRef<{ sessionId?: string | null; pages: StableChatPage[] }>({ pages: [] })
       const lastStreamingPageKeysRef = useRef<ReadonlySet<string>>(new Set())
@@ -303,6 +306,18 @@ export const ChatArea = memo(
         [activePages, measuredPageHeights, renderPageSelection],
       )
 
+      // 稳定签名：仅在实际展示的消息集合变化时才变。
+      // 流式期间页面结构不变（相同页面、相同消息 ID），签名保持稳定，
+      // 避免 IntersectionObserver effect 每 token 重订阅。
+      const domMessageSignature = useMemo(() => {
+        const parts: string[] = []
+        for (const pageIndex of renderPageSelection) {
+          const page = activePages[pageIndex]
+          if (page) parts.push(page.messageIds.join(','))
+        }
+        return parts.join('|')
+      }, [renderPageSelection, activePages])
+
       const clearPendingLoadMoreTimer = useCallback(() => {
         if (pendingLoadMoreTimerRef.current === null) return
         window.clearTimeout(pendingLoadMoreTimerRef.current)
@@ -340,6 +355,7 @@ export const ChatArea = memo(
           if (scrollSnapshotRafRef.current !== null) cancelAnimationFrame(scrollSnapshotRafRef.current)
           if (pendingAnchorClearRafRef.current !== null) cancelAnimationFrame(pendingAnchorClearRafRef.current)
           if (pendingSessionResetRafRef.current !== null) cancelAnimationFrame(pendingSessionResetRafRef.current)
+          if (heightFlushRafRef.current !== null) cancelAnimationFrame(heightFlushRafRef.current)
         }
       }, [clearPendingLoadMoreTimer, clearPendingScrollTimer])
 
@@ -610,7 +626,7 @@ export const ChatArea = memo(
         elements.forEach(element => observer.observe(element))
 
         return () => observer.disconnect()
-      }, [activePages, expandedPageRange.endIndex, expandedPageRange.startIndex])
+      }, [domMessageSignature, expandedPageRange.endIndex, expandedPageRange.startIndex])
 
       useEffect(() => {
         if (!pendingScrollMessageId) return
@@ -637,15 +653,35 @@ export const ChatArea = memo(
 
       const updateMeasuredPageHeight = useCallback((pageKey: string, nextHeight: number) => {
         if (nextHeight <= 0) return
-        setMeasuredPageHeights(previous => {
-          const current = previous[pageKey] ?? null
-          if (current !== null && Math.abs(current - nextHeight) < 1) return previous
-          const root = scrollRef.current
-          if (root && !isAtBottomRef.current && current !== null && Math.abs(current - nextHeight) >= 1) {
-            pendingLayoutAnchorRef.current = captureLoadMoreAnchor(root)
-          }
-          const next = { ...previous, [pageKey]: nextHeight }
-          return next
+        // 入队而非立即 setState——同帧内多个 ResizeObserver 回调
+        // 会合并为一次 setMeasuredPageHeights，避免每 token 级联重渲染
+        pendingHeightUpdatesRef.current.set(pageKey, nextHeight)
+
+        if (heightFlushRafRef.current !== null) return
+        heightFlushRafRef.current = requestAnimationFrame(() => {
+          heightFlushRafRef.current = null
+          const pending = pendingHeightUpdatesRef.current
+          pendingHeightUpdatesRef.current = new Map()
+          if (pending.size === 0) return
+
+          setMeasuredPageHeights(previous => {
+            let next = previous
+            let changed = false
+            for (const [key, height] of pending) {
+              const current = next[key] ?? null
+              if (current !== null && Math.abs(current - height) < 1) continue
+              if (!changed) {
+                next = { ...previous }
+                changed = true
+              }
+              next[key] = height
+              const root = scrollRef.current
+              if (root && !isAtBottomRef.current && current !== null && Math.abs(current - height) >= 1) {
+                pendingLayoutAnchorRef.current = captureLoadMoreAnchor(root)
+              }
+            }
+            return changed ? next : previous
+          })
         })
       }, [])
 

--- a/src/hooks/useSyntaxHighlight.ts
+++ b/src/hooks/useSyntaxHighlight.ts
@@ -1,10 +1,8 @@
-import { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback } from 'react'
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import { ShikiStreamTokenizer } from 'shiki-stream'
 import {
   codeToHtml,
-  codeToHtmlSyncIfLoaded,
   codeToTokens,
-  codeToTokensSyncIfLoaded,
   getLoadedHighlighterForLanguage,
   type ShikiThemeInput,
 } from '../lib/shiki'
@@ -521,25 +519,10 @@ export function useSyntaxHighlight(code: string, options: HighlightOptions & { m
   const [isLoading, setIsLoading] = useState(false)
   const prevKeyRef = useRef<{ code: string; lang: string; themeKey: string } | null>(null)
 
-  useLayoutEffect(() => {
-    if (!enabled || delayMs > 0) return
-
-    const syncResult =
-      mode === 'html'
-        ? codeToHtmlSyncIfLoaded(code, { lang: normalizedLang, theme: resolvedTheme.theme })
-        : codeToTokensSyncIfLoaded(code, { lang: normalizedLang, theme: resolvedTheme.theme })?.tokens
-
-    if (syncResult) {
-      if (mode === 'html') {
-        htmlCache.set(cacheKey, syncResult as string)
-      } else {
-        tokensCache.set(cacheKey, syncResult as HighlightTokens)
-      }
-      setOutputState({ key: outputKey, value: syncResult })
-      setIsLoading(false)
-    }
-  }, [cacheKey, code, delayMs, enabled, mode, normalizedLang, outputKey, resolvedTheme.theme])
-
+  // 原先此处有 useLayoutEffect 做同步高亮（codeToTokensSyncIfLoaded），
+  // 会在浏览器绘制前阻塞主线程——500 行代码耗时 ~150ms，1000 行 ~300ms。
+  // 删除后由下方 useEffect 的异步路径接管：先绘制纯文本，再通过
+  // scheduleQueuedHighlight（含 yieldToMainThread）逐块高亮，不阻塞交互。
   useEffect(() => {
     // Even when highlighting is temporarily disabled by viewport/lifecycle state,
     // keep already-computed results available after layout changes or remounts.


### PR DESCRIPTION
## 起因

用了一阵子 OpenCodeUI 之后，我发现有时候界面会突然卡一下，主要是两种情况：

1. **切对话的时候**，卡个 1-2 秒，点啥都没反应
2. **AI 输出长回复的时候**（特别是带大段代码的），交互会变得很钝

我电脑本身性能是没问题的，开别的软件都正常，所以应该是这个应用本身的问题。我自己对前端性能这块不算特别熟，就用 AI 帮忙一起排查了一下。

## 排查过程

让 AI 帮我读了代码，结合 Chrome DevTools 录制的结果，定位到三个地方有问题。为了确认不是瞎猜，还写了几个小脚本跑数据验证了一下：

**1. 代码高亮在渲染前同步执行，把主线程卡死了**

`useSyntaxHighlight.ts` 里有个 `useLayoutEffect`，会在浏览器绘制之前同步跑 Shiki 的 `codeToTokens`。实测下来：

- 100 行代码 ~30ms
- 500 行 ~150ms  
- 1000 行 ~300ms

切到一个有 10 来个代码块的对话，这些同步调用叠在一起就是 1 秒多的阻塞，界面当然没反应了。

**2. 流式输出时 IntersectionObserver 每个 token 都在重新订阅**

`ChatArea.tsx` 里那个 IntersectionObserver 的 effect 依赖了 `activePages`，但这个数组引用在流式时每个 token 都会变（因为页面内容在更新），导致 effect 每个 token 都重跑一遍——每次都 `querySelectorAll` 全量扫一遍再重新 observe，纯属浪费。

**3. 流式时高度更新每个 token 都触发一次 setState**

ResizeObserver 监测到页面高度变化就调 `setMeasuredPageHeights`，流式时高度一直在涨，所以每来一个 token 就 setState 一次，连锁反应导致 ChatArea 不停重渲染。

## 修复

三个问题都是针对性的小改动：

### 1. 去掉同步高亮，走异步路径
把 `useLayoutEffect` 里那段同步调用 `codeToTokensSyncIfLoaded` 的代码删了。其实下面已经有一个 `useEffect` 的异步路径（带 `scheduleQueuedHighlight` 和 `yieldToMainThread`），本来就能处理高亮，只是之前被同步路径抢先了。现在先渲染纯文本，再异步高亮，不会卡住交互。

### 2. 给 IntersectionObserver 换个稳定的依赖
加了一个 `domMessageSignature`，就是根据当前展开的页面里的消息 ID 拼一个字符串。流式时页面结构没变（还是那些消息），所以签名不变，effect 就不会重跑了。

### 3. 高度更新用 rAF 批处理
加了个 `pendingHeightUpdatesRef` 收集同帧内的多次更新，用 `requestAnimationFrame` 合并成一次 `setState`。一帧内不管 ResizeObserver 触发多少次，最后只更新一次状态。

## 验证

- TypeScript 编译 0 错误
- 现有测试 327 个全过
- 改动只涉及 2 个文件，+51 / -32 行

## 改动文件

```
src/hooks/useSyntaxHighlight.ts  | 删除 useLayoutEffect 同步高亮
src/features/chat/ChatArea.tsx   | IO 依赖稳定化 + 高度更新 rAF 批处理
```

## 预期效果

| 场景 | 之前 | 之后 |
|------|------|------|
| 切到有 10 个代码块的对话 | 卡 ~1.5 秒 | 基本无感 |
| 流式输出 30 个 token | setState 30 次 | 每帧最多 1 次 |
| 流式时点按钮/输入 | 偶发没反应 | 正常响应 |

排查和修复的过程中 AI 帮了不少忙，代码改动是我自己确认过逻辑的。如果有什么写得不对的地方欢迎指出。
