### PR TITLE
fix(侧边栏): 稳定 session 拉取 effect，避免 /session 请求风暴

### DIFF
--- a/src/features/chat/sidebar/SidePanel.tsx
+++ b/src/features/chat/sidebar/SidePanel.tsx
@@ -295,6 +295,9 @@ export function SidePanel({
   )
   // 缓存通过 API 拉取的 session 数据（sessions 列表中不存在的）
   const [fetchedSessions, setFetchedSessions] = useState<Record<string, ApiSession>>({})
+  // 防止 busySessions 等数组引用抖动时 cancel+重拉，导致 /session 风暴
+  const inflightSessionIdsRef = useRef(new Set<string>())
+  const failedSessionIdsRef = useRef(new Set<string>())
 
   // 为 active sessions 构建 sessionId -> ApiSession 的查找表
   const sessionLookup = useMemo(() => {
@@ -343,53 +346,84 @@ export function SidePanel({
 
   // 切服务器时清空跨目录 fetch 缓存，避免串服
   useEffect(() => {
-    return serverStore.onServerChange(() => setFetchedSessions({}))
+    return serverStore.onServerChange(() => {
+      setFetchedSessions({})
+      inflightSessionIdsRef.current.clear()
+      failedSessionIdsRef.current.clear()
+    })
   }, [])
+
+  // 需要补全的 session 集合：用内容 key 稳定，避免 busySessions 数组引用抖动触发重拉
+  const missingSessionsKey = useMemo(() => {
+    const byId = new Map<string, { sessionId: string; directory?: string; pinned?: boolean }>()
+    const add = (sessionId: string, directory?: string, pinned?: boolean) => {
+      if (sessionLookup.has(sessionId)) return
+      const existing = byId.get(sessionId)
+      if (existing) {
+        byId.set(sessionId, {
+          sessionId,
+          directory: existing.directory || directory,
+          pinned: existing.pinned || pinned,
+        })
+        return
+      }
+      byId.set(sessionId, { sessionId, directory, pinned })
+    }
+
+    for (const entry of busySessions) add(entry.sessionId, entry.directory)
+    for (const entry of notifications) add(entry.sessionId, entry.directory)
+    for (const entry of pinnedEntries) add(entry.sessionId, entry.directory, true)
+    if (selectedSessionId) add(selectedSessionId, currentDirectory || undefined)
+
+    return Array.from(byId.values())
+      .map(e => `${e.sessionId}\0${e.directory ?? ''}\0${e.pinned ? '1' : '0'}`)
+      .sort()
+      .join('|')
+  }, [busySessions, notifications, pinnedEntries, sessionLookup, selectedSessionId, currentDirectory])
 
   // 异步拉取不在 lookup 中的 active/notification/pinned/selected session
   useEffect(() => {
-    const allNeeded: Array<{ sessionId: string; directory?: string; pinned?: boolean }> = [
-      ...busySessions.map(e => ({ sessionId: e.sessionId, directory: e.directory })),
-      ...notifications.map(e => ({ sessionId: e.sessionId, directory: e.directory })),
-      ...pinnedEntries.map(e => ({ sessionId: e.sessionId, directory: e.directory, pinned: true })),
-    ]
-    if (selectedSessionId && !sessionLookup.has(selectedSessionId)) {
-      allNeeded.push({ sessionId: selectedSessionId, directory: currentDirectory || '' })
-    }
+    if (!missingSessionsKey) return
 
-    const missing = allNeeded.filter(entry => !sessionLookup.has(entry.sessionId))
+    const missing: Array<{ sessionId: string; directory?: string; pinned?: boolean }> = []
+    for (const token of missingSessionsKey.split('|')) {
+      const [sessionId, directory, pinned] = token.split('\0')
+      if (!sessionId) continue
+      if (sessionLookup.has(sessionId)) continue
+      if (inflightSessionIdsRef.current.has(sessionId)) continue
+      if (failedSessionIdsRef.current.has(sessionId)) continue
+      missing.push({
+        sessionId,
+        directory: directory || undefined,
+        pinned: pinned === '1',
+      })
+    }
     if (missing.length === 0) return
 
-    let cancelled = false
-    const fetchMissing = async () => {
-      const results: Record<string, ApiSession> = {}
-      await Promise.allSettled(
-        missing.map(async entry => {
-          try {
-            const session = await getSession(entry.sessionId, entry.directory)
-            if (!cancelled) {
-              results[session.id] = session
-              if (entry.pinned) {
-                pinnedSessionsStore.update(session.id, {
-                  directory: session.directory || entry.directory,
-                  title: session.title || session.id.slice(0, 12) + '...',
-                })
-              }
-            }
-          } catch {
-            // 拉失败则继续留在 unavailablePinnedEntries
+    for (const entry of missing) {
+      inflightSessionIdsRef.current.add(entry.sessionId)
+    }
+
+    void Promise.allSettled(
+      missing.map(async entry => {
+        try {
+          const session = await getSession(entry.sessionId, entry.directory)
+          inflightSessionIdsRef.current.delete(entry.sessionId)
+          setFetchedSessions(prev => (prev[session.id] ? prev : { ...prev, [session.id]: session }))
+          if (entry.pinned) {
+            pinnedSessionsStore.update(session.id, {
+              directory: session.directory || entry.directory,
+              title: session.title || session.id.slice(0, 12) + '...',
+            })
           }
-        }),
-      )
-      if (!cancelled && Object.keys(results).length > 0) {
-        setFetchedSessions(prev => ({ ...prev, ...results }))
-      }
-    }
-    fetchMissing()
-    return () => {
-      cancelled = true
-    }
-  }, [busySessions, notifications, pinnedEntries, sessionLookup, selectedSessionId, currentDirectory])
+        } catch {
+          inflightSessionIdsRef.current.delete(entry.sessionId)
+          // 失败只记一次，避免 SSE/busy 抖动时无限重试 /session
+          failedSessionIdsRef.current.add(entry.sessionId)
+        }
+      }),
+    )
+  }, [missingSessionsKey, sessionLookup])
 
   // ---- 子 session 展示数据 ----
   const rootSessionIds = useMemo(() => new Set(sessions.map(s => s.id)), [sessions])

--- a/src/store/activeSessionStore.ts
+++ b/src/store/activeSessionStore.ts
@@ -50,6 +50,30 @@ interface ActiveSessionState {
 
 type Subscriber = () => void
 
+function isSameBusySessions(a: ActiveSessionEntry[], b: ActiveSessionEntry[]): boolean {
+  if (a === b) return true
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    const left = a[i]
+    const right = b[i]
+    if (left.sessionId !== right.sessionId) return false
+    if (left.title !== right.title || left.directory !== right.directory) return false
+    if (left.pendingAction?.type !== right.pendingAction?.type) return false
+    if (left.pendingAction?.description !== right.pendingAction?.description) return false
+    if (left.status.type !== right.status.type) return false
+    if (left.status.type === 'retry' && right.status.type === 'retry') {
+      if (
+        left.status.attempt !== right.status.attempt ||
+        left.status.message !== right.status.message ||
+        left.status.next !== right.status.next
+      ) {
+        return false
+      }
+    }
+  }
+  return true
+}
+
 // ============================================
 // Store
 // ============================================
@@ -101,7 +125,10 @@ class ActiveSessionStore {
           pendingAction: pending ? { type: pending.type, description: pending.description } : undefined,
         } as ActiveSessionEntry
       })
-    this.cachedBusySessions = entries
+    // 内容不变时复用旧数组引用，避免 useBusySessions 订阅方因引用抖动重渲染
+    if (!isSameBusySessions(this.cachedBusySessions, entries)) {
+      this.cachedBusySessions = entries
+    }
     this.cachedBusyCount = entries.length
   }
 


### PR DESCRIPTION
## 问题

当跨域连接服务器且带 Authorization（密码）时，浏览器会在每个非简单请求前发一次 CORS 预检（OPTIONS）。在大量 SSE 活动下，`activeSessionStore` 里的 `busySessions` 每次通知都会换成新的数组引用，导致 `SidePanel` 的 `useEffect` 反复重跑、取消在途的 `getSession` 并把它们重新发起，从而产生每秒几十条到几百条 `/session` 请求。

## 根因

两处问题：

1. **`src/store/activeSessionStore.ts`** — `recomputeDerived()` 每次都把新数组赋给 `cachedBusySessions`，即使内容没变。所有 `useSyncExternalStore` 订阅方在每次 store 通知时都会拿到新引用。

2. **`src/features/chat/sidebar/SidePanel.tsx`** — 负责拉取缺失 session 的 `useEffect` 依赖 `[busySessions, notifications, pinnedEntries, ...]`。当 busySessions 引用变化时，effect：
   - 执行清理（`cancelled = true`），丢弃在途 `getSession` 结果
   - 重新运行，发现同样的 session 仍是「缺失」（结果被丢弃了）
   - 重启相同的拉取
   - 每个 SSE tick 重复 → 永不收敛 → 无限 /session 风暴

## 修复

**`activeSessionStore.ts`**：在替换数组引用前，先比较新条目与已缓存的条目。若内容不变则复用旧数组——避免上游出现不必要的重渲染。

**`SidePanel.tsx`**：
- 不再依赖数组引用，而是从真正需要的 sessionId + directory 派生一个稳定的内容 key（`missingSessionsKey`）
- 用 ref 记录在途和永久失败的 sessionId，避免重复请求和失败时的无限重试
- 去掉 cancel+重启 模式，改用基于 ref 的去重

## 验证

- `tsc --noEmit` 通过
- 合并进 fork 分支时无冲突（相对 v0.6.30 基线）
- 修复后，正常 SSE 活动下的 `/session` 请求收敛为每个缺失 session 只拉一次，而非无限重试