### PR TITLE
fix(message): 修复 StrictMode 下消息入场动画残留固定高度导致折叠卡死

### DIFF
--- a/src/features/message/MessageRenderer.tsx
+++ b/src/features/message/MessageRenderer.tsx
@@ -385,23 +385,24 @@ function useEntryGrowAnimation(
       return
     }
 
+    // 始终把 DOM 还原干净：StrictMode 开发期会双调用 effect（mount→cleanup→mount），
+    // 第一次的 WAAPI 动画若不被真正 cancel，会在后台跑完并把固定 height 写回 DOM，
+    // 而 cancel 时 finished promise 会 reject，所以无论正常结束还是被取消都要清空。
+    const clear = () => {
+      el.style.height = ''
+      el.style.clipPath = ''
+    }
+
     const targetHeight = el.scrollHeight
     el.style.height = '0px'
     el.style.clipPath = 'inset(0 -100% 0 -100%)'
-    let cancelled = false
-    animate(el, { height: `${targetHeight}px` }, { duration: ENTRY_GROW_DURATION_MS / 1000, ease: 'easeOut' }).then(
-      () => {
-        if (cancelled) return
-        el.style.height = ''
-        el.style.clipPath = ''
-        finish()
-      },
-    )
+    const controls = animate(el, { height: `${targetHeight}px` }, { duration: ENTRY_GROW_DURATION_MS / 1000, ease: 'easeOut' })
+    controls.then(clear)
+
     return () => {
-      cancelled = true
-      // 虚拟行中途卸载也放行，避免 Working 壳永远等不到入场完成
-      el.style.height = ''
-      el.style.clipPath = ''
+      // 真停掉动画，避免后台残留写入；再兜底清一次 DOM
+      controls.stop()
+      clear()
       finish()
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
**问题**

开发模式（React StrictMode）下，如果用户消息处于折叠状态且其对应的流式响应尚未结束，展开折叠气泡后 content 溢出、输入区域消失。查看 HTML 可见 `style="height: 260px"`（即折叠预览高度）锁死在消息 wrapper 上，重新切回 tab 后因组件重建而正常。

生产构建（stripped StrictMode）无此问题，deploy/cloudflare 正常运行。

**根因**

`useEntryGrowAnimation` 用 `motion/mini` `animate` 播放入场动画（0 → scrollHeight）。React StrictMode 在开发模式会双重调用 `useLayoutEffect`：

1. 第一次 mount：设置 `height=\'0px\'`，启动 WAAPI 动画。
2. 立即 cleanup：置 `cancelled=true` + 清 `height` + 调用 `finish()`（标记 `isEntryGrowComplete`），但**没有真正 `cancel()` 掉 WAAPI 动画**。
3. 第二次 mount：因 `isEntryGrowComplete` 已为 true，effect 提前 return，不再处理动画。
4. 后台的第一轮动画持续运行至结束，`onfinish` 将 `height:260px` 写回 DOM。`.then` 中因 `cancelled=true` 跳过清空 → 高度固化。
5. 展开折叠后 wrapper 仍被 260px 撑开，content 溢出、不推挤下方布局。

**修复**

- 持有 `animate()` 返回的 `controls`，cleanup 中调用 `controls.stop()` 真正终止后台动画。
- 提取 `clear()` 函数统一负责清空 `height`/`clipPath`，不依赖 `cancelled` 标志。
- `controls.then(clear)` 同时覆盖 resolve（正常结束）和 reject（被 cancel 时 motion 的 finished promise 会 reject）两种情况。
- cleanup 中同时调用 `stop()` + `clear()` + `finish()`，确保在任何卸载路径下 DOM 都被还原。

**验证**

- 开发模式（StrictMode 开启）下，折叠气泡展开后 `style.height` 正确还原，布局正常。
- 生产构建不变。
- TypeScript 类型检查通过，无新增依赖。'