### PR TITLE
refactor(chat): input-event-driven scroll-follow redesign

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -236,7 +236,7 @@ export const CodeBlock = memo(function CodeBlock({
         className={`rounded-sm overflow-hidden bg-bg-200/25 contain-content ${className}`}
         style={containerStyle}
       >
-        <div className={scrollClasses} style={maxHeight ? { maxHeight } : undefined}>
+        <div data-scrollable className={scrollClasses} style={maxHeight ? { maxHeight } : undefined}>
           {content}
         </div>
       </div>
@@ -275,7 +275,7 @@ export const CodeBlock = memo(function CodeBlock({
       )}
 
       {/* Scrollable content */}
-      <div className={scrollClasses} style={maxHeight ? { maxHeight } : undefined}>
+      <div data-scrollable className={scrollClasses} style={maxHeight ? { maxHeight } : undefined}>
         {content}
       </div>
     </div>

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -773,6 +773,7 @@ const WrappedSplitDiffView = memo(function WrappedSplitDiffView({
   return (
     <div
       ref={containerRef}
+      data-scrollable
       className="overflow-y-auto overflow-x-hidden custom-scrollbar font-mono text-[length:var(--fs-code)] h-full"
       onScroll={handleScroll}
       style={maxHeight !== undefined ? { maxHeight } : undefined}
@@ -1115,6 +1116,7 @@ const SplitDiffView = memo(function SplitDiffView({
   return (
     <div
       ref={containerRef}
+      data-scrollable
       className="overflow-y-auto overflow-x-hidden custom-scrollbar font-mono text-[length:var(--fs-code)] h-full"
       style={maxHeight !== undefined ? { maxHeight } : undefined}
       onScroll={handleScroll}
@@ -1418,6 +1420,7 @@ const UnifiedDiffView = memo(function UnifiedDiffView({
   return (
     <div
       ref={containerRef}
+      data-scrollable
       className="overflow-y-auto overflow-x-hidden custom-scrollbar font-mono text-[length:var(--fs-code)] h-full"
       style={maxHeight !== undefined ? { maxHeight } : undefined}
       onScroll={handleScroll}
@@ -1586,6 +1589,7 @@ const WrappedUnifiedDiffView = memo(function WrappedUnifiedDiffView({
   return (
     <div
       ref={containerRef}
+      data-scrollable
       className="overflow-y-auto overflow-x-hidden custom-scrollbar font-mono text-[length:var(--fs-code)] h-full"
       onScroll={handleScroll}
       style={maxHeight !== undefined ? { maxHeight } : undefined}

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -1655,7 +1655,7 @@ export const HighlightedCode = memo(function HighlightedCode({
   }, [filePath, language])
 
   return (
-    <div className={`overflow-auto ${className}`} style={maxHeight ? { maxHeight } : undefined}>
+    <div data-scrollable className={`overflow-auto ${className}`} style={maxHeight ? { maxHeight } : undefined}>
       <CodeBlock code={code} language={lang} />
     </div>
   )

--- a/src/components/ui/ScrollArea.tsx
+++ b/src/components/ui/ScrollArea.tsx
@@ -17,6 +17,7 @@ export const ScrollArea = forwardRef<HTMLDivElement, ScrollAreaProps>(
     return (
       <div
         ref={ref}
+        data-scrollable
         className={`overflow-y-auto overflow-x-hidden ${className}`}
         style={{
           maxHeight: typeof maxHeight === 'number' ? `${maxHeight}px` : maxHeight,

--- a/src/features/chat/ChatArea.tsx
+++ b/src/features/chat/ChatArea.tsx
@@ -437,6 +437,7 @@ export const ChatArea = memo(
       const autoForceScroll = auto.forceScrollToBottom
       const autoScrollBottom = auto.scrollToBottom
       const autoPause = auto.pause
+      const autoSetStreaming = auto.setStreaming
       const userScrolledRef = auto.userScrolledRef
       const autoSetPinToBottom = auto.setPinToBottom
       const spacerHeight = bottomSpacerHeight(bottomPadding)
@@ -447,6 +448,9 @@ export const ChatArea = memo(
       // 给 message tree 里的 disclosure widget 用：用户主动操作（展开/折叠）
       // 时通知这里停止贴底跟随。值 stable（pause 是 useCallback），不会引起消费方 re-render。
       const autoScrollCtxValue = useMemo(() => ({ pause: autoPause }), [autoPause])
+
+      // 同步 isStreaming 到 useAutoScroll —— selection 只在流式时才影响跟随
+      useEffect(() => { autoSetStreaming(isStreaming) }, [autoSetStreaming, isStreaming])
 
       // ── 滚动状态（同步计算，不使用 rAF） ──
       const prevState = useRef({ overflow: false, bottom: true, jump: false })

--- a/src/features/chat/ChatArea.tsx
+++ b/src/features/chat/ChatArea.tsx
@@ -40,6 +40,7 @@ import {
 } from './chatPageModel'
 import { useTheme } from '../../hooks/useTheme'
 import { useAutoScroll } from './virtual/useAutoScroll'
+import { AutoScrollProvider } from '../../hooks/AutoScrollContext'
 import { useEmptyWorkingShellGate } from './virtual/useEmptyWorkingShellGate'
 
 const NOOP = () => {}
@@ -110,6 +111,8 @@ interface ChatAreaProps {
   bottomPadding?: number
   onVisibleMessageIdsChange?: (ids: string[]) => void
   onAtBottomChange?: (atBottom: boolean) => void
+  /** 用户跟随状态变化时调用：true=正在贴底跟随，false=用户主动停止跟随 */
+  onFollowingChange?: (following: boolean) => void
 }
 
 export type ChatAreaHandle = {
@@ -329,7 +332,7 @@ export const ChatArea = memo(
         loadState = 'idle', loadError, connectionError, onOpenSettings,
         hasMoreHistory = false, onLoadMore, onUndo, onFork, canUndo,
         registerMessage, retryStatus = null, bottomPadding = 0,
-        onVisibleMessageIdsChange, onAtBottomChange,
+        onVisibleMessageIdsChange, onAtBottomChange, onFollowingChange,
       },
       ref,
     ) => {
@@ -415,6 +418,7 @@ export const ChatArea = memo(
       const onLoadMoreRef = useRef(onLoadMore); onLoadMoreRef.current = onLoadMore
       const onVisibleIdsRef = useRef(onVisibleMessageIdsChange); onVisibleIdsRef.current = onVisibleMessageIdsChange
       const onAtBottomRef = useRef(onAtBottomChange); onAtBottomRef.current = onAtBottomChange
+      const onFollowingRef = useRef(onFollowingChange); onFollowingRef.current = onFollowingChange
       const hasMoreRef = useRef(hasMoreHistory); hasMoreRef.current = hasMoreHistory
       const loadStateRef = useRef(loadState); loadStateRef.current = loadState
       const thresholdRef = useRef(atBottomThreshold); thresholdRef.current = atBottomThreshold
@@ -430,17 +434,19 @@ export const ChatArea = memo(
       const autoSetScrollRef = auto.setScrollRef
       const autoSetContentRef = auto.setContentRef
       const autoHandleScroll = auto.handleScroll
-      const autoHandleWheel = auto.handleWheel
-      const autoHandleInteraction = auto.handleInteraction
       const autoForceScroll = auto.forceScrollToBottom
       const autoScrollBottom = auto.scrollToBottom
       const autoPause = auto.pause
-      const autoMarkAuto = auto.markAuto
       const userScrolledRef = auto.userScrolledRef
+      const autoSetPinToBottom = auto.setPinToBottom
       const spacerHeight = bottomSpacerHeight(bottomPadding)
       // 贴底判断必须读 ref：wheel→stop 后 state 还没 re-render，
       // 若仍用 state，同一帧的 ResizeObserver 会误判仍可贴底。
       const shouldAnchorBottom = () => !userScrolledRef.current
+
+      // 给 message tree 里的 disclosure widget 用：用户主动操作（展开/折叠）
+      // 时通知这里停止贴底跟随。值 stable（pause 是 useCallback），不会引起消费方 re-render。
+      const autoScrollCtxValue = useMemo(() => ({ pause: autoPause }), [autoPause])
 
       // ── 滚动状态（同步计算，不使用 rAF） ──
       const prevState = useRef({ overflow: false, bottom: true, jump: false })
@@ -502,7 +508,6 @@ export const ChatArea = memo(
         // 预写 total height，避免浏览器把新 offset clamp 到旧高度（oc 同款）
         scrollToFn: (offset, options, instance) => {
           if (contentRef.current) contentRef.current.style.height = `${instance.getTotalSize()}px`
-          autoMarkAuto(scrollRef.current)
           elementScroll(offset, options, instance)
         },
         anchorTo: 'end',
@@ -540,13 +545,13 @@ export const ChatArea = memo(
               })
             })
           }
-          // 核心修复：用户已上滚（userScrolledRef）时，临时关掉 anchorTo:'end'，
+          // 用户已上滚（userScrolledRef）时，临时关掉 anchorTo:'end'，
           // 阻止 virtual-core resizeItem 内部的 wasAtEnd 路径（applyScrollAdjustment 拉回）。
           // wasAtEnd 用 getVirtualDistanceFromEnd()（基于内部 scrollOffset），
           // 但 React commit 阶段 ref 回调触发 measureElement 时 scroll 事件还没 fire，
           // scrollOffset 是陈旧的（仍指向底部），wasAtEnd 误判为 true → 拉回。
-          // userScrolledRef 由 handleWheel 上滚设 true，只由 handleWheel 下滚回底设 false，
-          // handleScroll 不清它（避免流式增长推回时误清）。
+          // userScrolledRef 现在只由输入事件设置（useAutoScroll 的 wheel/touch/...），
+          // handleScroll 在用户回到底部阈值内时清掉。
           if (userScrolledRef.current) {
             const opts = (virtualizer as any).options
             const origAnchor = opts.anchorTo
@@ -569,7 +574,6 @@ export const ChatArea = memo(
               if (!(virtualizer as any).isAtEnd?.(80)) return
               const el = scrollRef.current
               if (!el) return
-              autoMarkAuto(el)
               const max = Math.max(0, el.scrollHeight - el.clientHeight)
               if (max - el.scrollTop >= 2) el.scrollTop = max
             })
@@ -679,10 +683,14 @@ export const ChatArea = memo(
         // 必须滚到整页底（含 retry/error + 输入框 spacer），不能只 scrollToEnd 虚拟消息区
         const el = scrollRef.current
         if (!el) return
-        autoMarkAuto(el)
         const max = Math.max(0, el.scrollHeight - el.clientHeight)
         if (max - el.scrollTop >= 2) el.scrollTop = max
-      }, [autoMarkAuto])
+      }, [])
+
+      // 把 pinToBottom 注入 useAutoScroll，让 drift 自愈路径能调到
+      useEffect(() => {
+        autoSetPinToBottom(pinToBottom)
+      }, [autoSetPinToBottom, pinToBottom])
 
       // ── 事件处理 ──
       const onScroll = useCallback(() => {
@@ -700,10 +708,9 @@ export const ChatArea = memo(
         autoHandleScroll()
       }, [updatePrependAnchor, computeScrollState, autoHandleScroll, loadMore, userScrolledRef])
 
-      const onWheel = useCallback((e: React.WheelEvent<HTMLDivElement>) => {
+      const onWheel = useCallback(() => {
         if (!prependLoading.current) clearPrepend()
-        autoHandleWheel(e.nativeEvent)
-      }, [autoHandleWheel, clearPrepend])
+      }, [clearPrepend])
 
       const onTouchStart = useCallback(() => {
         if (!prependLoading.current) clearPrepend()
@@ -770,6 +777,12 @@ export const ChatArea = memo(
         return () => cancelAnimationFrame(frame)
       }, [auto.userScrolled, autoScrollBottom, pinToBottom])
 
+      // 通知父组件跟随状态变化（toBottom 按钮的显隐依据）
+      // useLayoutEffect 避免新 session remount 时按钮闪烁
+      useLayoutEffect(() => {
+        onFollowingRef.current?.(!auto.userScrolled)
+      }, [auto.userScrolled])
+
       // fill effect
       useEffect(() => {
         if (!sessionId || loadState !== 'loaded' || isLoadingMore || auto.userScrolled || !hasMoreHistory) return
@@ -832,22 +845,16 @@ export const ChatArea = memo(
       useImperativeHandle(ref, () => ({
         scrollToBottom: () => {
           autoForceScroll()
-          pinToBottom()
         },
         scrollToBottomIfAtBottom: () => {
-          // userScrolled 守卫：用户上滚后 userScrolled=true，此函数由 onScrollRequest
-          //（每个 SSE chunk）调用。autoForceScroll() 的 force=true 会清掉 userScrolled，
-          // 导致 resizeItem 的 anchorTo toggle 失效 → wasAtEnd 恢复拉回。
-          // 不在此处清 userScrolled——用户主动下滚回底时 handleWheel 会清。
-          // 正常贴底跟随（userScrolled=false 时）不受影响。
+          // 每个 SSE chunk 调用一次。userScrolled=true（用户主动操作过）时直接 return，
+          // 否则贴底。不再用 prevState.bottom 做二次门控——
+          // 用户手势是唯一停止信号，drift 之类不应该让 chunk 停止 pin。
           if (userScrolledRef.current) return
-          if (!prevState.current.bottom) return
-          autoForceScroll()
           pinToBottom()
         },
         scrollToLastMessage: () => {
           if (timeline.length === 0) return
-          autoMarkAuto(scrollRef.current)
           virtualizer.scrollToIndex(timeline.length - 1, { align: 'end' })
         },
         scrollToMessageIndex: (index: number) => {
@@ -867,10 +874,11 @@ export const ChatArea = memo(
           autoPause()
           virtualizer.scrollToIndex(timelineIndex, { align: 'center' })
         },
-      }), [autoForceScroll, autoPause, autoMarkAuto, pinToBottom, virtualizer, timeline, visibleMessages, messageIdToTimelineIndex])
+      }), [autoForceScroll, autoPause, pinToBottom, virtualizer, timeline, visibleMessages, messageIdToTimelineIndex])
 
       return (
-        <div className="h-full overflow-hidden contain-strict relative">
+        <AutoScrollProvider value={autoScrollCtxValue}>
+          <div className="h-full overflow-hidden contain-strict relative">
           {loadState === 'loading' && visibleMessages.length === 0 && (
             <div className="absolute inset-0 z-10 flex items-center justify-center">
               <div className="flex flex-col items-center gap-3 text-text-400 session-loading-indicator">
@@ -891,7 +899,6 @@ export const ChatArea = memo(
             onWheel={onWheel}
             onTouchStart={onTouchStart}
             onScroll={onScroll}
-            onClick={autoHandleInteraction}
           >
             {visibleMessages.length > 0 && isLoadingMore && (
               <div className="flex justify-center py-3" aria-live="polite">
@@ -961,7 +968,8 @@ export const ChatArea = memo(
 
             <div style={{ height: spacerHeight }} aria-hidden="true" />
           </div>
-        </div>
+          </div>
+        </AutoScrollProvider>
       )
     },
   ),

--- a/src/features/chat/ChatPane.tsx
+++ b/src/features/chat/ChatPane.tsx
@@ -223,6 +223,8 @@ export const ChatPane = memo(function ChatPane({
     setVisibleMessageIds(ids)
   }, [])
   const [isAtBottom, setIsAtBottom] = useState(true)
+  /** 用户是否在贴底跟随（true=正在跟随，false=用户主动停止） */
+  const [isFollowing, setIsFollowing] = useState(true)
 
   const handleOutlineScrollToMessage = useCallback((messageId: string) => {
     chatAreaRef.current?.scrollToMessageId(messageId)
@@ -841,6 +843,7 @@ export const ChatPane = memo(function ChatPane({
                 bottomPadding={inputBoxHeight}
                 onVisibleMessageIdsChange={handleVisibleIdsChange}
                 onAtBottomChange={setIsAtBottom}
+                onFollowingChange={setIsFollowing}
               />
             )}
           </ErrorBoundary>
@@ -914,7 +917,7 @@ export const ChatPane = memo(function ChatPane({
           onClearRevert={clearRevert}
           registerInputBox={registerInputBox}
           isAtBottom={isAtBottom}
-          showScrollToBottom={!isAtBottom}
+          showScrollToBottom={!isFollowing}
           onScrollToBottom={() => chatAreaRef.current?.scrollToBottom()}
           collapsedPermission={
             !inlineToolRequests && pendingPermissionRequests.length > 0 && permissionCollapsed

--- a/src/features/chat/DESIGN.md
+++ b/src/features/chat/DESIGN.md
@@ -1,0 +1,250 @@
+# Chat scroll-follow design
+
+This document explains the design of the chat scroll-following system.
+If you're touching `useAutoScroll.ts`, `ChatArea.tsx`, or any input
+handler that affects scroll behavior, read this first.
+
+## Core principle
+
+`userScrolled` is the single source of truth for "is the user actively
+following the chat stream to the bottom". It is set ONLY by direct user
+input events, NEVER by `scroll` events alone.
+
+This is a deliberate inversion of the previous design, which tried to
+reverse-engineer user intent from `scroll` events using a `markAuto`
+timestamp token (programmatic writes were marked, then `scroll` events
+checked whether a recent mark existed). The old design had several
+unfixable bugs because some `scroll` events have no JS-visible input
+precursor (layout shifts, viewport resize clamps, find-in-page, history
+restoration) — see `CONSTRAINTS` memory #60.
+
+## State machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> following
+    following --> stopped: stopFollow (wheel-up / touch / scrollbar / key-up / selection-start / disclosure-expand)
+    stopped --> following: forceScrollToBottom (button)
+    stopped --> following: tryRecover (wheel-down / key-down / OS_DRAG_END)\n+ atBottom
+    stopped --> following: tryRecover opened window\n+ scroll event reaches atBottom within 500ms
+    following --> following: drift (content grows)\n→ scheduleRecoverPin
+```
+
+Two states, three transition types. No intermediate state.
+
+## Input → intent mapping
+
+| Input | Condition | Action |
+|---|---|---|
+| `wheel` (deltaY < 0) | target in chat root, not editable, no nested boundary | `stopFollow()` |
+| `wheel` (deltaY > 0) | target in chat root, not editable, no nested boundary | mark recovery gesture; `handleScroll` completes it at bottom |
+| `wheel` (any direction) | target inside marked nested scrollable, movement stays inside it | no-op for chat follow |
+| `wheel` (deltaY < 0) | marked nested scrollable is already at top | `stopFollow()` |
+| `wheel` (deltaY > 0) | marked nested scrollable is already at bottom | mark recovery gesture; outer scroll may complete it |
+| `touchstart` | target in chat root, not editable | `stopFollow()` + reset `touchMaxDownRef` |
+| `touchmove` | during a touch gesture | update `touchMaxDownRef` (max downward displacement) |
+| `touchend` | `touchMaxDownRef > 10` (real downward drag) | `tryRecover()` |
+| `touchend` | no downward drag (tap / up-fling) | no-op |
+| `pointerdown` on scrollbar | target === scroll root, clientX in scrollbar region | `stopFollow()` |
+| `pointerup` | (any) | no-op (mouse-up is not a "scroll down" gesture) |
+| `keydown` PageUp/Home/ArrowUp | focus in chat root, not editable | `stopFollow()` |
+| `keydown` PageDown/End/ArrowDown | focus in chat root, not editable | `tryRecover()` |
+| `selectionchange` empty → non-empty | selection anchor in chat root | `stopFollow()` |
+| `selectionchange` non-empty → empty | (any) | no-op |
+| `OS_DRAG_START` (overlayScrollbar) | custom event from custom scrollbar thumb | `stopFollow()` |
+| `OS_DRAG_END` (overlayScrollbar) | custom event on pointerup from thumb | `tryRecover()` |
+| disclosure expand (`withScrollLock(_, true)`) | | `stopFollow()` |
+| disclosure collapse (`withScrollLock(_, false)`) | | no-op |
+| `scrollToMessageId` / `scrollToMessageIndex` | | calls `pause()` (= `stopFollow`) |
+
+## Recovery rules
+
+`userScrolled` is cleared by:
+
+1. `forceScrollToBottom()` — imperative "scroll to bottom" button
+2. `tryRecover()` or `markRecoverGesture()` — invoked by an explicit "down" input:
+   - If `scrollTop` is within `bottomThreshold` → clear immediately
+   - Otherwise → open a 500ms recovery window; subsequent `scroll` events
+     that find `scrollTop` back at bottom will complete the recovery.
+     This handles iOS momentum and "drag-to-bottom-then-release-with-1px-error".
+3. The recovery window closes on: success, timeout (500ms elapsed), or any
+   subsequent `stopFollow` / `setScrolled` call.
+
+`scroll` events themselves **do not** clear `userScrolled` outside of an
+active recovery window — this is what makes "tiny wheel-up persists stop"
+work correctly.
+
+## Why this works
+
+The fundamental insight is that user input events have well-defined
+intent at the moment they fire:
+
+- `wheel` with `deltaY < 0` → user wants to go up
+- `touchstart` → user is touching (likely about to scroll)
+- `pointerdown` on scrollbar → user is dragging the scrollbar
+- `keydown` PageUp → user wants to go up
+- `selectionchange` empty → non-empty → user is selecting text
+
+Each input declares its intent. We don't need to infer it from a
+downstream `scroll` event that conflates user and programmatic scrolls.
+
+## Why nested scrollables need special handling
+
+When the wheel target is inside a nested scrollable (code block, diff
+viewer, long thinking block), the user is reading content *inside* that
+block, not navigating the chat. Wheel-down inside a code block doesn't
+mean "I want to follow the chat" — it means "scroll this code down".
+
+Detection: `findScrollableAncestor(target, root)` finds the nearest
+ancestor marked with `data-scrollable`. `shouldMarkBoundaryGesture()`
+then checks whether the wheel delta would move that nested element past
+its top or bottom boundary. This mirrors OpenCode's boundary model:
+scrolling inside a block is private to that block; only an overflow
+attempt becomes an outer chat gesture.
+
+New nested vertical scroll components should mark their scroll viewport
+with `data-scrollable`. Shared `ScrollArea`, `CodeBlock`, `DiffViewer`,
+and Markdown code-preview viewports already do this.
+
+## Bottom threshold
+
+Single threshold: `bottomThreshold = 10` (px). Used for:
+
+- `tryRecover` deciding whether to clear `userScrolled`
+- `handleScroll` deciding whether to schedule `recoverPin`
+
+The 60/150px thresholds in `ChatArea.tsx` are for `isAtBottom` (passed
+to `useMobileCollapse` for the input-box pill behavior) and are
+unrelated to follow state.
+
+## AutoScrollContext
+
+Disclosure widgets (Tool, Reasoning, Task, Todo, Subtask, System,
+MessageError, ProcessCollapse) live deep in the message tree, far from
+ChatArea which owns the `useAutoScroll` instance. They use
+`useDisclosureScrollLock`, which internally `useContext(AutoScrollContext)`
+to get a `pause` callback wired to `useAutoScroll.pause`.
+
+The context value is stable (memoized on `auto.pause`, which is itself
+a stable `useCallback`), so consuming components don't re-render when
+the value changes (it doesn't change).
+
+## ToBottom button visibility
+
+Driven by `userScrolled` (via `onFollowingChange` callback from
+`ChatArea` to `ChatPane`), NOT by positional `isAtBottom`. This means
+a tiny wheel-up that doesn't move scroll position will still show the
+button (because `userScrolled = true`).
+
+This is correct: the button is the recovery mechanism for "user has
+stopped following". Whether they're positionally near the bottom is
+irrelevant to whether they want to recover.
+
+## Testing
+
+29 integration tests in `useAutoScroll.test.tsx` cover the state machine
+end-to-end (wheel, touch, keyboard, OS_DRAG, recovery window, nested
+scrollable, rapid events). Tests use a `Harness` component that calls
+`setScrollRef` from `useLayoutEffect` (matching React's production commit
+order: ref callbacks fire before `useEffect`).
+
+Manual verification still recommended for browser-only behaviors
+(real momentum scrolling, capture phase edge cases, getComputedStyle
+under actual CSS):
+
+1. Streaming stays pinned to bottom
+2. Tiny wheel-up persists stop (button shows)
+3. Wheel-down recovers when reaching bottom (immediate or via window)
+4. Touch scroll: drag up stops, genuine drag down to bottom recovers (tap doesn't)
+5. Scrollbar drag (custom overlayScrollbar): stops on dragstart, recovers on dragend if at bottom
+6. Keyboard: PageUp stops, PageDown recovers at bottom
+7. Text selection stops following; clearing selection doesn't recover
+8. Disclosure expand stops; collapse doesn't change state
+9. Wheel inside code block only affects chat when it overflows the block boundary
+10. Click "scroll to bottom" button always recovers
+11. iOS momentum: drag down, release with 1-2px error → still recovers within 500ms window
+
+## Key scenario sequence diagrams
+
+### Tiny wheel-up persists stop
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant W as wheel listener
+    participant H as handleScroll
+    participant S as userScrolled
+
+    U->>W: wheel-up (deltaY=-3, only moves 3px)
+    W->>S: stopFollow() → userScrolled=true
+    Note over S: button shows
+    Note over W: scroll event fires (scrollTop still in atBottom zone)
+    W->>H: scroll event
+    H->>H: check recovery window: none active
+    H->>H: userScrolled=true → return early
+    Note over S: still true (persists stop)
+```
+
+### Disclosure expand during streaming
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant D as disclosure widget
+    participant C as AutoScrollContext
+    participant A as useAutoScroll
+
+    U->>D: click expand toggle
+    D->>D: withScrollLock(() => setExpanded(true), expanding=true)
+    D->>C: pause() via context
+    C->>A: stopFollow()
+    A->>A: userScrolled=true
+    Note over A: streaming chunk arrives → scrollToBottomIfAtBottom returns early
+    Note over A: user can read the expanded content
+```
+
+### iOS touch drag-down + momentum recovery
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant T as touch listeners
+    participant H as handleScroll
+    participant S as userScrolled
+
+    U->>T: touchstart (y=500)
+    T->>S: stopFollow() + reset touchMaxDownRef
+    U->>T: touchmove (y=100, finger moved up 400px = scroll down 400px)
+    T->>T: touchMaxDownRef = 400
+    U->>T: touchend (release at scrollTop=497, 3px from bottom)
+    T->>T: touchMaxDownRef > 10 → tryRecover()
+    T->>T: atBottom? 500-497=3 < 10 → close, but momentum continues
+    Note over T: actually 500-497=3, in threshold → tryRecover clears immediately
+    Note over S: userScrolled=false
+    Note over U: alt: release at scrollTop=485 (15px from bottom)
+    T->>T: tryRecover → not atBottom → open 500ms window
+    U->>H: momentum fires scroll events
+    H->>H: scrollTop reaches 495 → within window → setScrolled(false)
+    Note over S: userScrolled=false (recovered via window)
+```
+
+### Wheel inside nested code block (only boundary overflow escapes)
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant W as wheel listener
+    participant F as findScrollableAncestor
+    participant S as userScrolled
+
+    U->>W: wheel-down (deltaY=+50) inside code block
+    W->>F: findScrollableAncestor(target, root)
+    F-->>W: returns code-block div (data-scrollable)
+    W->>F: shouldMarkBoundaryGesture(delta, nested)
+    F-->>W: false (nested block still has room)
+    Note over S: chat follow state is unchanged
+    U->>W: wheel-down again at code-block bottom
+    W->>F: shouldMarkBoundaryGesture(delta, nested)
+    F-->>W: true (wheel would overflow nested bottom)
+    W->>S: mark recovery gesture; outer scroll can recover at bottom
+```

--- a/src/features/chat/DESIGN.md
+++ b/src/features/chat/DESIGN.md
@@ -41,8 +41,9 @@ Two states, three transition types. No intermediate state.
 | `wheel` (any direction) | target inside marked nested scrollable, movement stays inside it | no-op for chat follow |
 | `wheel` (deltaY < 0) | marked nested scrollable is already at top | `stopFollow()` |
 | `wheel` (deltaY > 0) | marked nested scrollable is already at bottom | mark recovery gesture; outer scroll may complete it |
-| `touchstart` | target in chat root, not editable | `stopFollow()` + reset `touchMaxDownRef` |
-| `touchmove` | during a touch gesture | update `touchMaxDownRef` (max downward displacement) |
+| `touchstart` | target in chat root, not editable | record start position (no state change) |
+| `touchmove` | finger down >10px (scroll up gesture) | `stopFollow()` |
+| `touchmove` | finger up (scroll down) | update `touchMaxDownRef` |
 | `touchend` | `touchMaxDownRef > 10` (real downward drag) | `tryRecover()` |
 | `touchend` | no downward drag (tap / up-fling) | no-op |
 | `pointerdown` on scrollbar | target === scroll root, clientX in scrollbar region | `stopFollow()` |

--- a/src/features/chat/DESIGN.md
+++ b/src/features/chat/DESIGN.md
@@ -49,7 +49,7 @@ Two states, three transition types. No intermediate state.
 | `pointerup` | (any) | no-op (mouse-up is not a "scroll down" gesture) |
 | `keydown` PageUp/Home/ArrowUp | focus in chat root, not editable | `stopFollow()` |
 | `keydown` PageDown/End/ArrowDown | focus in chat root, not editable | `tryRecover()` |
-| `selectionchange` empty → non-empty | selection anchor in chat root | `stopFollow()` |
+| `selectionchange` empty → non-empty | selection anchor in chat root, **only during active streaming** | `stopFollow()` |
 | `selectionchange` non-empty → empty | (any) | no-op |
 | `OS_DRAG_START` (overlayScrollbar) | custom event from custom scrollbar thumb | `stopFollow()` |
 | `OS_DRAG_END` (overlayScrollbar) | custom event on pointerup from thumb | `tryRecover()` |
@@ -87,6 +87,11 @@ intent at the moment they fire:
 
 Each input declares its intent. We don't need to infer it from a
 downstream `scroll` event that conflates user and programmatic scrolls.
+
+**Selection during idle is a no-op.** `selectionchange` only calls
+`stopFollow` when `isStreaming` is true. When the chat is idle,
+selecting text to copy/reference doesn't break follow state or show
+the toBottom button — there's nothing to unfollow.
 
 ## Why nested scrollables need special handling
 

--- a/src/features/chat/virtual/useAutoScroll.test.tsx
+++ b/src/features/chat/virtual/useAutoScroll.test.tsx
@@ -1,0 +1,524 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { useLayoutEffect } from 'react'
+import { useAutoScroll } from './useAutoScroll'
+
+/**
+ * 集成测试 —— 验证 input-event-driven 状态机的核心转换。
+ *
+ * jsdom 限制：scrollTop/scrollHeight/clientHeight 默认都是 0 且只读，
+ * 需要用 Object.defineProperty 注入 getter。getComputedStyle 默认返回空字符串，
+ * 需要在测试里 spy。
+ */
+
+interface ElDims {
+  scrollHeight?: number
+  clientHeight?: number
+  scrollTop?: number
+}
+
+function mountScrollEl(dims: ElDims = {}) {
+  const state = {
+    scrollHeight: dims.scrollHeight ?? 1000,
+    clientHeight: dims.clientHeight ?? 500,
+    scrollTop: dims.scrollTop ?? 500, // 默认在底部
+  }
+  const el = document.createElement('div')
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => state.scrollHeight })
+  Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => state.clientHeight })
+  Object.defineProperty(el, 'scrollTop', {
+    configurable: true,
+    get: () => state.scrollTop,
+    set: (v: number) => {
+      state.scrollTop = v
+    },
+  })
+  Object.defineProperty(el, 'style', { configurable: true, value: {} })
+  document.body.innerHTML = ''
+  document.body.appendChild(el)
+  return { el, state }
+}
+
+function setDims(state: { scrollHeight: number; clientHeight: number; scrollTop: number }, patch: ElDims) {
+  if (patch.scrollHeight !== undefined) state.scrollHeight = patch.scrollHeight
+  if (patch.clientHeight !== undefined) state.clientHeight = patch.clientHeight
+  if (patch.scrollTop !== undefined) state.scrollTop = patch.scrollTop
+}
+
+function fireWheel(target: Element, deltaY: number) {
+  target.dispatchEvent(new WheelEvent('wheel', { deltaY, bubbles: true, cancelable: true }))
+}
+
+function fireKey(target: Element, key: string) {
+  target.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }))
+}
+
+function makeTouch(y: number): Touch {
+  return { clientY: y } as unknown as Touch
+}
+
+function fireTouchStart(target: Element, y = 500) {
+  const e = new TouchEvent('touchstart', { bubbles: true, cancelable: true })
+  Object.defineProperty(e, 'touches', { value: [makeTouch(y)], configurable: true })
+  target.dispatchEvent(e)
+}
+
+function fireTouchMove(target: Element, y: number) {
+  const e = new TouchEvent('touchmove', { bubbles: true, cancelable: true })
+  Object.defineProperty(e, 'touches', { value: [makeTouch(y)], configurable: true })
+  target.dispatchEvent(e)
+}
+
+function fireTouchEnd(target: Element) {
+  const e = new TouchEvent('touchend', { bubbles: true, cancelable: true })
+  Object.defineProperty(e, 'touches', { value: [], configurable: true })
+  target.dispatchEvent(e)
+}
+
+/**
+ * TestComponent 模拟 ChatArea：在 useLayoutEffect 里调 setScrollRef，
+ * 确保 ref 在 useAutoScroll 的 useEffect 运行前就绑定好（生产时 ref callback
+ * 在 commit 阶段调用，先于 useEffect）。
+ */
+let capturedAuto: ReturnType<typeof useAutoScroll> | null = null
+function Harness({ targetEl }: { targetEl: HTMLElement | null }) {
+  const auto = useAutoScroll(10)
+  // eslint-disable-next-line react-hooks/globals -- test-only side effect to expose latest hook value
+  capturedAuto = auto
+  useLayoutEffect(() => {
+    if (targetEl) auto.setScrollRef(targetEl)
+  }, [targetEl])
+  return null
+}
+
+function setup(el: HTMLElement | null) {
+  const utils = render(<Harness targetEl={el} />)
+  return {
+    /**
+     * 读最新 hook 返回值。注意：不要解构！
+     * `const { getResult } = setup()` 会把 getter 求值成一次性快照，
+     * 后续 setState re-render 后 capturedAuto 更新了也读不到。
+     */
+    getResult: () => capturedAuto!,
+    rerender: (nextEl: HTMLElement | null) => utils.rerender(<Harness targetEl={nextEl} />),
+    unmount: utils.unmount,
+  }
+}
+
+describe('useAutoScroll', () => {
+  afterEach(() => {
+    capturedAuto = null
+  })
+
+  it('initial state: not scrolled (following)', () => {
+    const { el } = mountScrollEl()
+    const { getResult } = setup(el)
+    expect(getResult().userScrolled).toBe(false)
+    expect(getResult().userScrolledRef.current).toBe(false)
+  })
+
+  describe('wheel events', () => {
+    it('wheel-up (deltaY<0) stops following', () => {
+      const { el } = mountScrollEl()
+      const { getResult } = setup(el)
+      expect(getResult().userScrolled).toBe(false)
+
+      act(() => fireWheel(el, -100))
+      expect(getResult().userScrolled).toBe(true)
+    })
+
+    it('wheel-down (deltaY>0) at bottom recovers when scroll handles the gesture', () => {
+      const { el, state } = mountScrollEl({ scrollHeight: 1000, clientHeight: 500, scrollTop: 495 })
+      const { getResult } = setup(el)
+
+      act(() => fireWheel(el, -100))
+      expect(getResult().userScrolled).toBe(true)
+
+      setDims(state, { scrollTop: 495 })
+      act(() => fireWheel(el, 100))
+      act(() => getResult().handleScroll())
+      expect(getResult().userScrolled).toBe(false)
+    })
+
+    it('wheel-down NOT at bottom does NOT recover', () => {
+      const { el, state } = mountScrollEl({ scrollHeight: 1000, clientHeight: 500, scrollTop: 200 })
+      const { getResult } = setup(el)
+
+      act(() => fireWheel(el, -100))
+      expect(getResult().userScrolled).toBe(true)
+
+      setDims(state, { scrollTop: 200 })
+      act(() => fireWheel(el, 100))
+      expect(getResult().userScrolled).toBe(true)
+    })
+
+    it('wheel inside nested scrollable only stops when the nested block reaches a boundary', () => {
+      const outer = document.createElement('div')
+      const inner = document.createElement('div')
+      let innerScrollTop = 300
+      Object.defineProperty(outer, 'scrollHeight', { configurable: true, get: () => 1000 })
+      Object.defineProperty(outer, 'clientHeight', { configurable: true, get: () => 500 })
+      Object.defineProperty(outer, 'scrollTop', { configurable: true, get: () => 500, set: () => {} })
+      Object.defineProperty(outer, 'style', { configurable: true, value: {} })
+      Object.defineProperty(inner, 'scrollHeight', { configurable: true, get: () => 1000 })
+      Object.defineProperty(inner, 'clientHeight', { configurable: true, get: () => 200 })
+      Object.defineProperty(inner, 'scrollTop', { configurable: true, get: () => innerScrollTop })
+      inner.dataset.scrollable = ''
+      document.body.innerHTML = ''
+      document.body.appendChild(outer)
+      outer.appendChild(inner)
+
+      const { getResult } = setup(outer)
+
+      // 嵌套块内部仍有空间时，wheel 只滚动嵌套块，不影响 chat 跟随。
+      act(() => fireWheel(inner, 100))
+      expect(getResult().userScrolled).toBe(false)
+
+      // 到顶部后继续向上，边界溢出意图传给 chat。
+      innerScrollTop = 0
+      act(() => fireWheel(inner, -100))
+      expect(getResult().userScrolled).toBe(true)
+
+      // 已经停止后，在嵌套块底部继续向下，边界意图打开恢复窗口；
+      // 外层 scroll 到底时完成恢复。
+      innerScrollTop = 800
+      act(() => fireWheel(inner, 100))
+      act(() => getResult().handleScroll())
+      expect(getResult().userScrolled).toBe(false)
+    })
+
+    it('wheel on editable element does not affect state', () => {
+      const { el } = mountScrollEl()
+      const input = document.createElement('input')
+      el.appendChild(input)
+      const { getResult } = setup(el)
+
+      act(() => fireWheel(input, -100))
+      expect(getResult().userScrolled).toBe(false)
+    })
+  })
+
+  describe('keyboard events', () => {
+    it('PageUp stops following', () => {
+      const { el } = mountScrollEl()
+      const { getResult } = setup(el)
+
+      act(() => fireKey(el, 'PageUp'))
+      expect(getResult().userScrolled).toBe(true)
+    })
+
+    it('ArrowDown at bottom recovers', () => {
+      const { el } = mountScrollEl({ scrollTop: 495 })
+      const { getResult } = setup(el)
+
+      act(() => fireKey(el, 'PageUp'))
+      expect(getResult().userScrolled).toBe(true)
+
+      act(() => fireKey(el, 'ArrowDown'))
+      expect(getResult().userScrolled).toBe(false)
+    })
+
+    it('keyboard on editable element does not affect state', () => {
+      const { el } = mountScrollEl()
+      const textarea = document.createElement('textarea')
+      el.appendChild(textarea)
+      const { getResult } = setup(el)
+
+      act(() => fireKey(textarea, 'PageUp'))
+      expect(getResult().userScrolled).toBe(false)
+    })
+  })
+
+  describe('touch events', () => {
+    it('touchstart stops following', () => {
+      const { el } = mountScrollEl()
+      const { getResult } = setup(el)
+
+      act(() => fireTouchStart(el))
+      expect(getResult().userScrolled).toBe(true)
+    })
+
+    it('touchend (plain release, no downward drag) does NOT recover', () => {
+      const { el, state } = mountScrollEl({ scrollTop: 495 })
+      const { getResult } = setup(el)
+
+      act(() => fireTouchStart(el, 500))
+      expect(getResult().userScrolled).toBe(true)
+
+      // 没有 move（没向下滚），直接松手：不应解除 userScrolled
+      setDims(state, { scrollTop: 495 })
+      act(() => fireTouchEnd(el))
+      expect(getResult().userScrolled).toBe(true)
+    })
+
+    it('touchend recovers only after a genuine downward drag to bottom', () => {
+      const { el, state } = mountScrollEl({ scrollTop: 200 })
+      const { getResult } = setup(el)
+
+      act(() => fireTouchStart(el, 500))
+      expect(getResult().userScrolled).toBe(true)
+
+      // 手指上移 400px → 内容向下滚 400px，已到底部
+      setDims(state, { scrollTop: 495 })
+      act(() => fireTouchMove(el, 100))
+      act(() => fireTouchEnd(el))
+      expect(getResult().userScrolled).toBe(false)
+    })
+
+    it('touchend after an upward drag does NOT recover', () => {
+      const { el, state } = mountScrollEl({ scrollTop: 495 })
+      const { getResult } = setup(el)
+
+      act(() => fireTouchStart(el, 100))
+      expect(getResult().userScrolled).toBe(true)
+
+      // 手指下移（内容向上滚）→ 不是向下滚
+      setDims(state, { scrollTop: 480 })
+      act(() => fireTouchMove(el, 500))
+      act(() => fireTouchEnd(el))
+      expect(getResult().userScrolled).toBe(true)
+    })
+  })
+
+  describe('imperative API', () => {
+    it('pause() stops following', () => {
+      const { el } = mountScrollEl()
+      const { getResult } = setup(el)
+
+      act(() => getResult().pause())
+      expect(getResult().userScrolled).toBe(true)
+    })
+
+    it('pause() is no-op when content fits in viewport', () => {
+      const { el } = mountScrollEl({ scrollHeight: 100, clientHeight: 500 })
+      const { getResult } = setup(el)
+
+      act(() => getResult().pause())
+      expect(getResult().userScrolled).toBe(false)
+    })
+
+    it('forceScrollToBottom() recovers even if user had stopped', () => {
+      const { el, state } = mountScrollEl()
+      const { getResult } = setup(el)
+
+      act(() => fireWheel(el, -100))
+      expect(getResult().userScrolled).toBe(true)
+
+      act(() => getResult().forceScrollToBottom())
+      expect(getResult().userScrolled).toBe(false)
+      expect(state.scrollTop).toBe(500) // max = 1000 - 500
+    })
+
+    it('scrollToBottom(non-force) does nothing when user stopped', () => {
+      const { el, state } = mountScrollEl({ scrollTop: 100 })
+      const { getResult } = setup(el)
+
+      act(() => fireWheel(el, -100))
+      expect(getResult().userScrolled).toBe(true)
+
+      const before = state.scrollTop
+      act(() => getResult().scrollToBottom())
+      expect(getResult().userScrolled).toBe(true)
+      expect(state.scrollTop).toBe(before)
+    })
+  })
+
+  describe('handleScroll', () => {
+    it('does NOT clear userScrolled when at bottom (key invariant)', () => {
+      const { el, state } = mountScrollEl({ scrollTop: 495 })
+      const { getResult } = setup(el)
+
+      act(() => fireWheel(el, -100))
+      expect(getResult().userScrolled).toBe(true)
+
+      setDims(state, { scrollTop: 495 })
+      act(() => getResult().handleScroll())
+      expect(getResult().userScrolled).toBe(true)
+    })
+
+    it('schedules recoverPin when following but drifted off bottom', async () => {
+      const { el, state } = mountScrollEl({ scrollTop: 100 })
+      const { getResult } = setup(el)
+
+      const pinFn = vi.fn()
+      act(() => getResult().setPinToBottom(pinFn))
+
+      setDims(state, { scrollTop: 100 })
+      act(() => getResult().handleScroll())
+
+      await act(async () => {
+        await new Promise(r => requestAnimationFrame(r))
+      })
+      expect(pinFn).toHaveBeenCalled()
+    })
+
+    it('does NOT schedule recoverPin when user stopped', async () => {
+      const { el } = mountScrollEl({ scrollTop: 100 })
+      const { getResult } = setup(el)
+
+      const pinFn = vi.fn()
+      act(() => getResult().setPinToBottom(pinFn))
+
+      act(() => fireWheel(el, -100))
+      act(() => getResult().handleScroll())
+
+      await act(async () => {
+        await new Promise(r => requestAnimationFrame(r))
+      })
+      expect(pinFn).not.toHaveBeenCalled()
+    })
+
+    it('does NOT schedule recoverPin when at bottom (no drift)', async () => {
+      const { el, state } = mountScrollEl({ scrollTop: 495 })
+      const { getResult } = setup(el)
+
+      const pinFn = vi.fn()
+      act(() => getResult().setPinToBottom(pinFn))
+
+      setDims(state, { scrollTop: 495 })
+      act(() => getResult().handleScroll())
+
+      await act(async () => {
+        await new Promise(r => requestAnimationFrame(r))
+      })
+      expect(pinFn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('selection', () => {
+    it('does not crash when selectionchange fires with empty selection', () => {
+      const { el } = mountScrollEl()
+      const { getResult } = setup(el)
+
+      act(() => {
+        document.dispatchEvent(new Event('selectionchange'))
+      })
+      expect(getResult().userScrolled).toBe(false)
+    })
+  })
+
+  describe('recovery window', () => {
+    it('tryRecover NOT at bottom opens a recovery window; subsequent scroll to bottom recovers', () => {
+      const { el, state } = mountScrollEl({ scrollTop: 200 })
+      const { getResult } = setup(el)
+
+      // 用户停止
+      act(() => fireWheel(el, -100))
+      expect(getResult().userScrolled).toBe(true)
+
+      // wheel-down 但还没到底：打开恢复窗口，不立刻恢复
+      setDims(state, { scrollTop: 300 })
+      act(() => fireWheel(el, 100))
+      expect(getResult().userScrolled).toBe(true)
+
+      // momentum 把 scrollTop 带到底部 → handleScroll 在窗口内恢复
+      setDims(state, { scrollTop: 495 })
+      act(() => getResult().handleScroll())
+      expect(getResult().userScrolled).toBe(false)
+    })
+
+    it('recovery window closes when user stopFollow again', () => {
+      const { el, state } = mountScrollEl({ scrollTop: 200 })
+      const { getResult } = setup(el)
+
+      // 用户先停止
+      act(() => fireWheel(el, -100))
+      expect(getResult().userScrolled).toBe(true)
+
+      // wheel-down 但还没到底：打开恢复窗口，不立刻恢复
+      setDims(state, { scrollTop: 300 })
+      act(() => fireWheel(el, 100))
+      expect(getResult().userScrolled).toBe(true)
+
+      // 用户又向上滚 → stopFollow 关掉窗口
+      setDims(state, { scrollTop: 290 })
+      act(() => fireWheel(el, -100))
+      expect(getResult().userScrolled).toBe(true)
+
+      // 即使后续到达底部，没有窗口也不会被 scroll 事件清掉
+      setDims(state, { scrollTop: 495 })
+      act(() => getResult().handleScroll())
+      expect(getResult().userScrolled).toBe(true)
+    })
+  })
+
+  describe('OS_DRAG events (overlayScrollbar)', () => {
+    it('OS_DRAG_START stops following, OS_DRAG_END at bottom recovers', () => {
+      const { el, state } = mountScrollEl({ scrollTop: 495 })
+      const { getResult } = setup(el)
+
+      act(() => el.dispatchEvent(new CustomEvent('os-scroll-dragstart', { bubbles: true })))
+      expect(getResult().userScrolled).toBe(true)
+
+      setDims(state, { scrollTop: 495 })
+      act(() => el.dispatchEvent(new CustomEvent('os-scroll-dragend', { bubbles: true })))
+      expect(getResult().userScrolled).toBe(false)
+    })
+
+    it('OS_DRAG_END not at bottom does NOT recover', () => {
+      const { el, state } = mountScrollEl({ scrollTop: 100 })
+      const { getResult } = setup(el)
+
+      act(() => el.dispatchEvent(new CustomEvent('os-scroll-dragstart', { bubbles: true })))
+      expect(getResult().userScrolled).toBe(true)
+
+      setDims(state, { scrollTop: 100 })
+      act(() => el.dispatchEvent(new CustomEvent('os-scroll-dragend', { bubbles: true })))
+      expect(getResult().userScrolled).toBe(true)
+    })
+  })
+
+  describe('rapid / multiple events', () => {
+    it('100 rapid wheel-up events do not crash and end with userScrolled=true', () => {
+      const { el } = mountScrollEl()
+      const { getResult } = setup(el)
+
+      act(() => {
+        for (let i = 0; i < 100; i++) fireWheel(el, -100)
+      })
+      expect(getResult().userScrolled).toBe(true)
+    })
+
+    it('alternating wheel-up / wheel-down sequence ends with the last direction', () => {
+      const { el, state } = mountScrollEl({ scrollTop: 495 })
+      const { getResult } = setup(el)
+
+      // up, down, up, down
+      act(() => fireWheel(el, -100))
+      expect(getResult().userScrolled).toBe(true)
+
+      setDims(state, { scrollTop: 495 })
+      act(() => fireWheel(el, 100))
+      act(() => getResult().handleScroll())
+      expect(getResult().userScrolled).toBe(false)
+
+      act(() => fireWheel(el, -100))
+      expect(getResult().userScrolled).toBe(true)
+
+      setDims(state, { scrollTop: 495 })
+      act(() => fireWheel(el, 100))
+      act(() => getResult().handleScroll())
+      expect(getResult().userScrolled).toBe(false)
+    })
+  })
+
+  describe('nested scrollable + keyboard', () => {
+    it('PageUp inside a nested scrollable still stops (nested affects wheel only, not keyboard)', () => {
+      const outer = document.createElement('div')
+      const inner = document.createElement('div')
+      Object.defineProperty(outer, 'scrollHeight', { configurable: true, get: () => 1000 })
+      Object.defineProperty(outer, 'clientHeight', { configurable: true, get: () => 500 })
+      Object.defineProperty(outer, 'scrollTop', { configurable: true, get: () => 500, set: () => {} })
+      Object.defineProperty(outer, 'style', { configurable: true, value: {} })
+      document.body.innerHTML = ''
+      document.body.appendChild(outer)
+      outer.appendChild(inner)
+
+      inner.dataset.scrollable = ''
+
+      const { getResult } = setup(outer)
+      act(() => fireKey(inner, 'PageUp'))
+      expect(getResult().userScrolled).toBe(true)
+    })
+  })
+})

--- a/src/features/chat/virtual/useAutoScroll.test.tsx
+++ b/src/features/chat/virtual/useAutoScroll.test.tsx
@@ -395,6 +395,42 @@ describe('useAutoScroll', () => {
       })
       expect(getResult().userScrolled).toBe(false)
     })
+
+    it('selection during streaming stops following', () => {
+      const { el } = mountScrollEl()
+      const { getResult } = setup(el)
+
+      act(() => getResult().setStreaming(true))
+
+      // 模拟开始选中文字
+      const sel = {
+        toString: () => 'selected',
+        anchorNode: el,
+      } as unknown as Selection
+      vi.spyOn(window, 'getSelection').mockReturnValue(sel)
+
+      act(() => {
+        document.dispatchEvent(new Event('selectionchange'))
+      })
+      expect(getResult().userScrolled).toBe(true)
+    })
+
+    it('selection during idle (non-streaming) does NOT stop following', () => {
+      const { el } = mountScrollEl()
+      const { getResult } = setup(el)
+
+      // 不 setStreaming —— 默认 false
+      const sel = {
+        toString: () => 'selected',
+        anchorNode: el,
+      } as unknown as Selection
+      vi.spyOn(window, 'getSelection').mockReturnValue(sel)
+
+      act(() => {
+        document.dispatchEvent(new Event('selectionchange'))
+      })
+      expect(getResult().userScrolled).toBe(false)
+    })
   })
 
   describe('recovery window', () => {

--- a/src/features/chat/virtual/useAutoScroll.test.tsx
+++ b/src/features/chat/virtual/useAutoScroll.test.tsx
@@ -230,23 +230,43 @@ describe('useAutoScroll', () => {
   })
 
   describe('touch events', () => {
-    it('touchstart stops following', () => {
+    it('tap (touchstart + touchend, no movement) does NOT stop following', () => {
       const { el } = mountScrollEl()
       const { getResult } = setup(el)
 
-      act(() => fireTouchStart(el))
+      act(() => fireTouchStart(el, 500))
+      act(() => fireTouchEnd(el))
+      expect(getResult().userScrolled).toBe(false)
+    })
+
+    it('touchmove upward (finger down >10px) stops following', () => {
+      const { el } = mountScrollEl()
+      const { getResult } = setup(el)
+
+      act(() => fireTouchStart(el, 500))
+      act(() => fireTouchMove(el, 520)) // finger down 20px = scroll up
       expect(getResult().userScrolled).toBe(true)
+    })
+
+    it('small touchmove (<10px) does NOT stop following', () => {
+      const { el } = mountScrollEl()
+      const { getResult } = setup(el)
+
+      act(() => fireTouchStart(el, 500))
+      act(() => fireTouchMove(el, 508)) // finger down 8px = below threshold
+      expect(getResult().userScrolled).toBe(false)
     })
 
     it('touchend (plain release, no downward drag) does NOT recover', () => {
       const { el, state } = mountScrollEl({ scrollTop: 495 })
       const { getResult } = setup(el)
 
-      act(() => fireTouchStart(el, 500))
+      // 用 wheel-up 预设 userScrolled（touchstart 不再自动设置）
+      act(() => fireWheel(el, -100))
       expect(getResult().userScrolled).toBe(true)
 
-      // 没有 move（没向下滚），直接松手：不应解除 userScrolled
       setDims(state, { scrollTop: 495 })
+      act(() => fireTouchStart(el, 500))
       act(() => fireTouchEnd(el))
       expect(getResult().userScrolled).toBe(true)
     })
@@ -255,11 +275,12 @@ describe('useAutoScroll', () => {
       const { el, state } = mountScrollEl({ scrollTop: 200 })
       const { getResult } = setup(el)
 
-      act(() => fireTouchStart(el, 500))
+      act(() => fireWheel(el, -100))
       expect(getResult().userScrolled).toBe(true)
 
       // 手指上移 400px → 内容向下滚 400px，已到底部
       setDims(state, { scrollTop: 495 })
+      act(() => fireTouchStart(el, 500))
       act(() => fireTouchMove(el, 100))
       act(() => fireTouchEnd(el))
       expect(getResult().userScrolled).toBe(false)
@@ -269,11 +290,12 @@ describe('useAutoScroll', () => {
       const { el, state } = mountScrollEl({ scrollTop: 495 })
       const { getResult } = setup(el)
 
-      act(() => fireTouchStart(el, 100))
+      act(() => fireWheel(el, -100))
       expect(getResult().userScrolled).toBe(true)
 
       // 手指下移（内容向上滚）→ 不是向下滚
       setDims(state, { scrollTop: 480 })
+      act(() => fireTouchStart(el, 100))
       act(() => fireTouchMove(el, 500))
       act(() => fireTouchEnd(el))
       expect(getResult().userScrolled).toBe(true)

--- a/src/features/chat/virtual/useAutoScroll.ts
+++ b/src/features/chat/virtual/useAutoScroll.ts
@@ -70,26 +70,33 @@ function createInputHandlers(ctx: InputHandlerContext) {
     }
   }
 
-  const onTouchStart = (e: TouchEvent) => {
+  const isRelevantTouch = (e: TouchEvent): boolean => {
     const t = e.target instanceof Element ? e.target : null
-    if (!t || !el.contains(t)) return
-    if (t.closest(EDITABLE_SELECTOR)) return
-    stopFollow()
+    if (!t || !el.contains(t)) return false
+    if (t.closest(EDITABLE_SELECTOR)) return false
+    return true
+  }
+
+  const onTouchStart = (e: TouchEvent) => {
+    if (!isRelevantTouch(e)) return
     ctx.touchStartYRef.current = e.touches[0]?.clientY ?? 0
     ctx.touchMaxDownRef.current = 0
   }
 
   const onTouchMove = (e: TouchEvent) => {
+    if (!isRelevantTouch(e)) return
     const y = e.touches[0]?.clientY ?? 0
-    // 手指上移 = 内容向下滚，d>0 表示本次手势向下滚动过
+    // d > 0: 手指上移 = 内容向下滚（向下滚动）
+    // d < 0: 手指下移 = 内容向上滚（向上滚动）
     const d = ctx.touchStartYRef.current - y
     if (d > ctx.touchMaxDownRef.current) ctx.touchMaxDownRef.current = d
+    // 向上滚动手势（手指下移超过阈值）→ 停止跟随，和桌面端 wheel-up 一致
+    if (d < -10) stopFollow()
   }
 
-  const onTouchEnd = () => {
+  const onTouchEnd = (e: TouchEvent) => {
+    if (!isRelevantTouch(e)) return
     // 只有「本次触摸是向下滚动手势且已回到底部」才恢复跟随。
-    // 普通点击、上滚、或微小抖动都不算向下滚动 → 不解除 userScrolled，
-    // 否则会出现「刚解除贴底、松手就又被拉回底部」的问题。
     if (ctx.touchMaxDownRef.current > 10) tryRecover()
   }
 

--- a/src/features/chat/virtual/useAutoScroll.ts
+++ b/src/features/chat/virtual/useAutoScroll.ts
@@ -1,118 +1,314 @@
 /**
- * useAutoScroll — React 移植自 oc 的 createAutoScroll
+ * useAutoScroll — input-event-driven scroll-follow state machine
  *
- * 核心机制：
- * - userScrolled: 用户离开底部后置 true，阻止程序拉回底部
- * - markAuto/isAuto: 程序滚动时打标记（1500ms TTL, 2px 容差），
- *   防止自己的 scrollToBottom 被误判为用户滚动
- * - handleScroll 可无手势门控调用：靠 isAuto 区分程序滚动
- * - 所有回调稳定（useCallback + useMemo），避免 ref 回调重挂载
+ * 核心原则：userScrolled 只由**直接的用户输入**设置（wheel 向上、touch、滚动条
+ * 拖拽、键盘向上、selection 起、disclosure 展开、scroll-to-message）。
+ * 绝不由 scroll 事件单独设置。这意味着 layout clamp、virtualizer 调整、
+ * viewport resize 等任何「无用户手势」的滚动都不会破坏跟随 —— 它们不匹配
+ * 任何输入信号。
+ *
+ * 恢复（清掉 userScrolled）在三种情况下发生：
+ *   (a) forceScrollToBottom（命令式「回到底部」按钮）
+ *   (b) 显式向下输入时 scrollTop 已在 bottomThreshold 内 —— 立即恢复
+ *   (c) 显式向下输入时 scrollTop 还没到底 —— 打开 500ms 恢复窗口，
+ *       窗口内的 scroll 事件若发现已回到底部，就完成恢复。
+ *       解决 iOS momentum / 触屏「拖到底松手时差几 px」的边界。
+ *
+ * 关键：scroll 事件本身**不会**清 userScrolled，除非在显式向下输入打开的
+ * 恢复窗口内 —— 这样小幅 wheel-up 后紧随的 scroll 事件即使发现 atBottom=true
+ * 也不会把刚表达的停止意图清掉（没有窗口）。
+ *
+ * handleScroll 唯一职责：用户在跟随时若发生 drift（scrollTop 离开底部），
+ * 排一个 rAF 调 pinToBottom 写回去。
+ *
+ * 不再需要 markAuto/isAuto token —— 用户输入在事件源头捕获，
+ * 而不是从 scroll 事件里事后推断。
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { OS_DRAG_START, OS_DRAG_END } from '../../../lib/overlayScrollbar'
 
-const AUTO_TTL = 1500
-const AUTO_TOLERANCE = 2
+const SCROLL_UP_KEYS = new Set(['PageUp', 'Home', 'ArrowUp'])
+const SCROLL_DOWN_KEYS = new Set(['PageDown', 'End', 'ArrowDown'])
+
+/** tryRecover 没立即成功时打开的恢复窗口时长 —— 给 momentum / 连续 scroll 一个机会完成恢复 */
+const RECOVERY_WINDOW_MS = 500
+
+/** 这些元素上的 wheel / 键盘滚动不影响跟随状态（用户在编辑） */
+const EDITABLE_SELECTOR = 'input, textarea, select, [contenteditable="true"], [contenteditable=""]'
+
+/**
+ * 输入事件 handlers 工厂 + 统一 attach/detach。
+ * 把监听器配置从 useEffect 主体里抽出来，让 useAutoScroll 主流程更清晰。
+ * handlers 闭包捕获 ctx 里的 ref 和回调 —— 这些值由 useAutoScroll 提供。
+ */
+interface InputHandlerContext {
+  el: HTMLElement
+  stopFollow: () => void
+  tryRecover: () => void
+  markRecoverGesture: () => void
+  touchStartYRef: React.MutableRefObject<number>
+  touchMaxDownRef: React.MutableRefObject<number>
+  lastSelEmptyRef: React.MutableRefObject<boolean>
+}
+
+function createInputHandlers(ctx: InputHandlerContext) {
+  const { el, stopFollow, tryRecover, markRecoverGesture } = ctx
+
+  const onWheel = (e: WheelEvent) => {
+    const t = e.target instanceof Element ? e.target : null
+    if (!t || !el.contains(t)) return
+    if (t.closest(EDITABLE_SELECTOR)) return
+    const delta = normalizeWheelDelta(e, el)
+    const nested = findScrollableAncestor(t, el)
+    if (nested && !shouldMarkBoundaryGesture(nested, delta)) return
+    if (delta < 0) {
+      stopFollow()
+    } else if (delta > 0) {
+      // 下滚的实际恢复由 handleScroll 完成；这里仅打开用户恢复窗口。
+      markRecoverGesture()
+    }
+  }
+
+  const onTouchStart = (e: TouchEvent) => {
+    const t = e.target instanceof Element ? e.target : null
+    if (!t || !el.contains(t)) return
+    if (t.closest(EDITABLE_SELECTOR)) return
+    stopFollow()
+    ctx.touchStartYRef.current = e.touches[0]?.clientY ?? 0
+    ctx.touchMaxDownRef.current = 0
+  }
+
+  const onTouchMove = (e: TouchEvent) => {
+    const y = e.touches[0]?.clientY ?? 0
+    // 手指上移 = 内容向下滚，d>0 表示本次手势向下滚动过
+    const d = ctx.touchStartYRef.current - y
+    if (d > ctx.touchMaxDownRef.current) ctx.touchMaxDownRef.current = d
+  }
+
+  const onTouchEnd = () => {
+    // 只有「本次触摸是向下滚动手势且已回到底部」才恢复跟随。
+    // 普通点击、上滚、或微小抖动都不算向下滚动 → 不解除 userScrolled，
+    // 否则会出现「刚解除贴底、松手就又被拉回底部」的问题。
+    if (ctx.touchMaxDownRef.current > 10) tryRecover()
+  }
+
+  const onPointerDown = (e: PointerEvent) => {
+    // touch 走 touchstart 处理；这里只处理鼠标 / 笔
+    if (e.pointerType === 'touch') return
+    const t = e.target instanceof Element ? e.target : null
+    // 滚动条是 scroll root 自己渲染的，target === el
+    if (!t || t !== el) return
+    const rect = el.getBoundingClientRect()
+    const sbWidth = rect.width - el.clientWidth
+    if (sbWidth <= 0) return
+    if (e.clientX >= rect.right - sbWidth) stopFollow()
+  }
+
+  const onPointerUp = () => {
+    // 鼠标松开本身不是「向下滚动」手势，不恢复跟随。
+    // 鼠标向下滚动靠 wheel(deltaY>0) 恢复；滚动条拖拽靠 OS_DRAG_END 恢复。
+  }
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    const t = e.target instanceof Element ? e.target : null
+    if (!t || !el.contains(t)) return
+    if (t.closest(EDITABLE_SELECTOR)) return
+    if (SCROLL_UP_KEYS.has(e.key)) {
+      stopFollow()
+    } else if (SCROLL_DOWN_KEYS.has(e.key)) {
+      tryRecover()
+    }
+  }
+
+  const onSelectionChange = () => {
+    const sel = window.getSelection()
+    const isEmpty = !sel || sel.toString().length === 0
+    if (isEmpty === ctx.lastSelEmptyRef.current) return
+    ctx.lastSelEmptyRef.current = isEmpty
+    // 只有「开始选中文字」才停止跟随；清空 selection 不改变状态
+    if (isEmpty) return
+    // 只对 chat root 内的 selection 起反应
+    const node = sel.anchorNode
+    const nodeEl = node
+      ? (node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement)
+      : null
+    if (!nodeEl || !el.contains(nodeEl)) return
+    stopFollow()
+  }
+
+  // 自绘滚动条（overlayScrollbar）拖拽：原生 scrollbar 被全局隐藏，
+  // 它的 thumb 在父元素上且 stopPropagation，pointerdown 检测不到。
+  // 这里改监听 overlayScrollbar 广播的 dragstart/dragend。
+  const onOsDragStart = () => stopFollow()
+  const onOsDragEnd = () => tryRecover()
+
+  return {
+    onWheel,
+    onTouchStart,
+    onTouchMove,
+    onTouchEnd,
+    onPointerDown,
+    onPointerUp,
+    onKeyDown,
+    onSelectionChange,
+    onOsDragStart,
+    onOsDragEnd,
+  }
+}
+
+/** 用 AbortController 统一管理所有 listener 的注册/卸载 */
+function attachInputListeners(el: HTMLElement, h: ReturnType<typeof createInputHandlers>) {
+  const ac = new AbortController()
+  const capture = { capture: true, passive: true, signal: ac.signal }
+  const bubble = { passive: true, signal: ac.signal }
+  const keydownOpts = { signal: ac.signal }
+  const osOpts = { signal: ac.signal }
+
+  el.addEventListener('wheel', h.onWheel, capture)
+  el.addEventListener('touchstart', h.onTouchStart, capture)
+  el.addEventListener('touchmove', h.onTouchMove, capture)
+  el.addEventListener('touchend', h.onTouchEnd, bubble)
+  el.addEventListener('pointerdown', h.onPointerDown, capture)
+  el.addEventListener('pointerup', h.onPointerUp, bubble)
+  el.addEventListener('keydown', h.onKeyDown, keydownOpts)
+  el.addEventListener(OS_DRAG_START, h.onOsDragStart, osOpts)
+  el.addEventListener(OS_DRAG_END, h.onOsDragEnd, osOpts)
+  document.addEventListener('selectionchange', h.onSelectionChange, osOpts)
+
+  return () => ac.abort()
+}
+
+/**
+ * 从 target 向上找显式标记的嵌套滚动祖先（不含 root 自己）。
+ * 嵌套块使用 data-scrollable 表达边界，避免每次 wheel 都调用 getComputedStyle。
+ */
+function findScrollableAncestor(target: Element, root: HTMLElement): HTMLElement | null {
+  const nested = target.closest<HTMLElement>('[data-scrollable]')
+  if (!nested || nested === root || !root.contains(nested)) return null
+  return nested
+}
+
+function normalizeWheelDelta(event: WheelEvent, root: HTMLElement) {
+  if (event.deltaMode === 1) return event.deltaY * 40
+  if (event.deltaMode === 2) return event.deltaY * root.clientHeight
+  return event.deltaY
+}
+
+function shouldMarkBoundaryGesture(nested: HTMLElement, delta: number) {
+  const max = nested.scrollHeight - nested.clientHeight
+  if (max <= 1) return true
+  if (!delta) return false
+  if (delta < 0) return nested.scrollTop + delta <= 0
+  return delta > max - nested.scrollTop
+}
 
 export function useAutoScroll(bottomThreshold = 10) {
   const scrollElRef = useRef<HTMLElement | undefined>(undefined)
   const contentElRef = useRef<HTMLElement | undefined>(undefined)
   const userScrolledRef = useRef(false)
   const [userScrolled, setUserScrolled] = useState(false)
-
-  const autoMark = useRef<{ top: number; time: number } | undefined>(undefined)
-  const autoTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const lastSelEmptyRef = useRef(true)
+  const recoverPinFrame = useRef<number | undefined>(undefined)
+  /** 触摸手势中向下滚动的最大位移，用于 touchend 判断是否真的「向下滚到底」 */
+  const touchStartYRef = useRef(0)
+  const touchMaxDownRef = useRef(0)
+  /** 由 ChatArea 注入的「写到底部」函数，drift 时调用以恢复贴底 */
+  const pinToBottomRef = useRef<(() => void) | null>(null)
+  /**
+   * 恢复窗口的截止时间戳（Date.now() + RECOVERY_WINDOW_MS）。
+   * 0 = 没有窗口。显式向下输入在不在线底部时打开窗口，
+   * 之后 scroll 事件若发现已回到底部，就完成恢复。
+   * 解决 iOS momentum / 触屏「拖到底松手时差几 px」的边界。
+   */
+  const recoverUntilRef = useRef(0)
 
   const setScrolled = useCallback((v: boolean) => {
+    if (userScrolledRef.current === v) return
     userScrolledRef.current = v
     setUserScrolled(v)
+    recoverUntilRef.current = 0
   }, [])
 
-  const markAuto = useCallback((el?: HTMLElement | null) => {
-    const target = el ?? scrollElRef.current
-    if (!target) return
-    autoMark.current = { top: target.scrollHeight - target.clientHeight, time: Date.now() }
-    if (autoTimer.current) clearTimeout(autoTimer.current)
-    autoTimer.current = setTimeout(() => { autoMark.current = undefined }, AUTO_TTL)
+  /** 用户表达「停止跟随」：直接置 userScrolled=true，并关掉任何恢复窗口 */
+  const stopFollow = useCallback(() => {
+    const el = scrollElRef.current
+    if (el && el.scrollHeight - el.clientHeight <= 1) {
+      // 内容不足一屏，谈不上跟随
+      if (userScrolledRef.current) setScrolled(false)
+      return
+    }
+    recoverUntilRef.current = 0
+    setScrolled(true)
+  }, [setScrolled])
+
+  /**
+   * 用户表达「向下」意愿（wheel-down / 向下键 / touchend / pointerup）：
+   * 若 scrollTop 已回到 bottomThreshold 内，立即恢复跟随；
+   * 否则打开 500ms 恢复窗口 —— 让 momentum / 后续 scroll 事件完成恢复。
+   */
+  const tryRecover = useCallback(() => {
+    if (!userScrolledRef.current) return
+    const el = scrollElRef.current
+    if (!el) return
+    const max = el.scrollHeight - el.clientHeight
+    if (max - el.scrollTop < bottomThreshold) {
+      setScrolled(false)
+      return
+    }
+    recoverUntilRef.current = Date.now() + RECOVERY_WINDOW_MS
+  }, [bottomThreshold, setScrolled])
+
+  const markRecoverGesture = useCallback(() => {
+    if (!userScrolledRef.current) return
+    recoverUntilRef.current = Date.now() + RECOVERY_WINDOW_MS
   }, [])
 
-  const isAuto = useCallback((el: HTMLElement) => {
-    const a = autoMark.current
-    if (!a) return false
-    if (Date.now() - a.time > AUTO_TTL) { autoMark.current = undefined; return false }
-    return Math.abs(el.scrollTop - a.top) < AUTO_TOLERANCE
+  // ── 漂移自愈：scroll 事件发现离底但 userScrolled=false 时排个 rAF 写回底 ──
+  const scheduleRecoverPin = useCallback(() => {
+    if (recoverPinFrame.current !== undefined) return
+    recoverPinFrame.current = requestAnimationFrame(() => {
+      recoverPinFrame.current = undefined
+      if (userScrolledRef.current) return
+      pinToBottomRef.current?.()
+    })
   }, [])
 
+  const setPinToBottom = useCallback((fn: (() => void) | null) => {
+    pinToBottomRef.current = fn
+  }, [])
+
+  // ── scroll 事件：负责 drift pin 和 recovery window，永远不直接清 userScrolled（除恢复窗口内） ──
+  const handleScroll = useCallback(() => {
+    const el = scrollElRef.current
+    if (!el) return
+    const max = el.scrollHeight - el.clientHeight
+    const atBottom = max <= 1 || max - el.scrollTop < bottomThreshold
+
+    // 恢复窗口：用户表达过「向下」意愿后，给 momentum 一段时间把 scrollTop 带到底部
+    if (userScrolledRef.current && recoverUntilRef.current > 0) {
+      if (Date.now() > recoverUntilRef.current) {
+        recoverUntilRef.current = 0
+      } else if (atBottom) {
+        setScrolled(false)
+        return
+      }
+    }
+
+    if (userScrolledRef.current) return
+    if (!atBottom) scheduleRecoverPin()
+  }, [bottomThreshold, scheduleRecoverPin, setScrolled])
+
+  // ── 命令式动作 ──
   const scrollToBottom = useCallback((force: boolean) => {
     const el = scrollElRef.current
     if (!el) return
     if (force && userScrolledRef.current) setScrolled(false)
     if (!force && userScrolledRef.current) return
     const max = Math.max(0, el.scrollHeight - el.clientHeight)
-    if (max - el.scrollTop < 2) {
-      markAuto(el)
-      return
-    }
-    markAuto(el)
-    el.scrollTop = max
-  }, [markAuto, setScrolled])
-
-  const stop = useCallback(() => {
-    const el = scrollElRef.current
-    if (!el) return
-    if (el.scrollHeight - el.clientHeight <= 1) {
-      if (userScrolledRef.current) setScrolled(false)
-      return
-    }
-    if (userScrolledRef.current) return
-    setScrolled(true)
+    if (max - el.scrollTop >= 2) el.scrollTop = max
   }, [setScrolled])
 
-  const handleScroll = useCallback(() => {
-    const el = scrollElRef.current
-    if (!el) return
-    const max = el.scrollHeight - el.clientHeight
-    if (max <= 1) {
-      // isAuto 守卫：程序滚动（applyScrollAdjustment 经 scrollToFn→markAuto）
-      // 不清 userScrolled，只有真实用户滚动到无溢出时才清。
-      if (userScrolledRef.current && !isAuto(el)) setScrolled(false)
-      return
-    }
-    if (max - el.scrollTop < bottomThreshold) {
-      // isAuto 守卫：流式增长推回底部（程序滚动，isAuto=true）不清 userScrolled。
-      // 用户真实滚动回底（isAuto=false）才清，恢复贴底跟随。
-      if (userScrolledRef.current && !isAuto(el)) setScrolled(false)
-      return
-    }
-    if (!userScrolledRef.current && isAuto(el)) {
-      scrollToBottom(false)
-      return
-    }
-    stop()
-  }, [bottomThreshold, isAuto, scrollToBottom, setScrolled, stop])
-
-  const handleWheel = useCallback((e: WheelEvent) => {
-    const el = scrollElRef.current
-    if (!el) return
-    if (e.deltaY >= 0) {
-      // 下滚回底时恢复贴底跟随：用户主动下滚到阈值内才清 userScrolled。
-      // 流式增长推回不会走这里（不是 wheel 事件）。
-      if (userScrolledRef.current) {
-        const max = el.scrollHeight - el.clientHeight
-        if (max - el.scrollTop < bottomThreshold) setScrolled(false)
-      }
-      return
-    }
-    // 上滚立刻离底
-    const nested = (e.target instanceof Element ? e.target : undefined)?.closest('[data-scrollable]')
-    if (nested && nested !== el) return
-    // 直接写 ref，不等 React re-render——同帧的 RO/measure 必须立刻看到离底
-    if (!userScrolledRef.current) setScrolled(true)
-  }, [bottomThreshold, setScrolled])
-
-  const handleInteraction = useCallback(() => {
-    const sel = window.getSelection()
-    if (sel && sel.toString().length > 0) stop()
-  }, [stop])
+  const pause = stopFollow
 
   const setScrollRef = useCallback((el: HTMLElement | null) => {
     scrollElRef.current = el ?? undefined
@@ -123,40 +319,50 @@ export function useAutoScroll(bottomThreshold = 10) {
     contentElRef.current = el ?? undefined
   }, [])
 
-  // 不使用 contentRef ResizeObserver：
-  // measureElement 内置 RO → resizeItem → applyScrollAdjustment 已经处理了贴底。
-  // contentRef RO 会在 item 首次测量时触发（container height 变化），
-  // 把 scrollTop 拉回底部，覆盖 applyScrollAdjustment 的正确行为。
+  // ── 输入事件监听器：mount 一次，cleanup 通过 AbortController 统一 ──
+  useEffect(() => {
+    const el = scrollElRef.current
+    if (!el) return
+    const handlers = createInputHandlers({
+      el,
+      stopFollow,
+      tryRecover,
+      markRecoverGesture,
+      touchStartYRef,
+      touchMaxDownRef,
+      lastSelEmptyRef,
+    })
+    return attachInputListeners(el, handlers)
+  }, [markRecoverGesture, stopFollow, tryRecover])
 
-  useEffect(() => () => { if (autoTimer.current) clearTimeout(autoTimer.current) }, [])
+  useEffect(() => () => {
+    if (recoverPinFrame.current !== undefined) cancelAnimationFrame(recoverPinFrame.current)
+  }, [])
 
-  const reset = useCallback(() => {
-    setScrolled(false)
-  }, [setScrolled])
+  const reset = useCallback(() => setScrolled(false), [setScrolled])
 
   const resume = useCallback(() => {
     setScrolled(false)
     scrollToBottom(true)
   }, [scrollToBottom, setScrolled])
+
   const scrollToBottomCb = useCallback(() => scrollToBottom(false), [scrollToBottom])
   const forceScrollToBottom = useCallback(() => scrollToBottom(true), [scrollToBottom])
 
   return useMemo(() => ({
     setScrollRef,
     setContentRef,
+    setPinToBottom,
     handleScroll,
-    handleWheel,
-    handleInteraction,
-    pause: stop,
+    pause,
     reset,
     resume,
-    markAuto,
     scrollToBottom: scrollToBottomCb,
     forceScrollToBottom,
     userScrolledRef,
     userScrolled,
   }), [
-    setScrollRef, setContentRef, handleScroll, handleWheel, handleInteraction,
-    stop, reset, resume, markAuto, scrollToBottomCb, forceScrollToBottom, userScrolled,
+    setScrollRef, setContentRef, setPinToBottom, handleScroll, pause,
+    reset, resume, scrollToBottomCb, forceScrollToBottom, userScrolled,
   ])
 }

--- a/src/features/chat/virtual/useAutoScroll.ts
+++ b/src/features/chat/virtual/useAutoScroll.ts
@@ -49,6 +49,7 @@ interface InputHandlerContext {
   touchStartYRef: React.MutableRefObject<number>
   touchMaxDownRef: React.MutableRefObject<number>
   lastSelEmptyRef: React.MutableRefObject<boolean>
+  isStreamingRef: React.MutableRefObject<boolean>
 }
 
 function createInputHandlers(ctx: InputHandlerContext) {
@@ -121,6 +122,9 @@ function createInputHandlers(ctx: InputHandlerContext) {
   }
 
   const onSelectionChange = () => {
+    // 非流式时 selection 不影响跟随状态 —— 用户只是在复制/引用文字，
+    // 不应该导致 toBottom 按钮出现或下一条消息不贴底
+    if (!ctx.isStreamingRef.current) return
     const sel = window.getSelection()
     const isEmpty = !sel || sel.toString().length === 0
     if (isEmpty === ctx.lastSelEmptyRef.current) return
@@ -205,6 +209,8 @@ function shouldMarkBoundaryGesture(nested: HTMLElement, delta: number) {
 export function useAutoScroll(bottomThreshold = 10) {
   const scrollElRef = useRef<HTMLElement | undefined>(undefined)
   const contentElRef = useRef<HTMLElement | undefined>(undefined)
+  /** 是否正在流式输出 —— selection 只在流式时才影响跟随状态 */
+  const isStreamingRef = useRef(false)
   const userScrolledRef = useRef(false)
   const [userScrolled, setUserScrolled] = useState(false)
   const lastSelEmptyRef = useRef(true)
@@ -319,6 +325,10 @@ export function useAutoScroll(bottomThreshold = 10) {
     contentElRef.current = el ?? undefined
   }, [])
 
+  const setStreaming = useCallback((v: boolean) => {
+    isStreamingRef.current = v
+  }, [])
+
   // ── 输入事件监听器：mount 一次，cleanup 通过 AbortController 统一 ──
   useEffect(() => {
     const el = scrollElRef.current
@@ -331,6 +341,7 @@ export function useAutoScroll(bottomThreshold = 10) {
       touchStartYRef,
       touchMaxDownRef,
       lastSelEmptyRef,
+      isStreamingRef,
     })
     return attachInputListeners(el, handlers)
   }, [markRecoverGesture, stopFollow, tryRecover])
@@ -353,6 +364,7 @@ export function useAutoScroll(bottomThreshold = 10) {
     setScrollRef,
     setContentRef,
     setPinToBottom,
+    setStreaming,
     handleScroll,
     pause,
     reset,
@@ -362,7 +374,7 @@ export function useAutoScroll(bottomThreshold = 10) {
     userScrolledRef,
     userScrolled,
   }), [
-    setScrollRef, setContentRef, setPinToBottom, handleScroll, pause,
+    setScrollRef, setContentRef, setPinToBottom, setStreaming, handleScroll, pause,
     reset, resume, scrollToBottomCb, forceScrollToBottom, userScrolled,
   ])
 }

--- a/src/features/message/MessageRenderer.tsx
+++ b/src/features/message/MessageRenderer.tsx
@@ -503,7 +503,7 @@ const CollapsibleUserText = memo(function CollapsibleUserText({
       {showCollapse && (
         <button
           type="button"
-          onClick={() => withScrollLock(() => setExpanded(prev => !prev))}
+          onClick={() => withScrollLock(() => setExpanded(!expanded), !expanded)}
           className="mt-1 text-[length:var(--fs-sm)] text-text-400 hover:text-text-200 transition-colors"
           aria-expanded={expanded}
         >
@@ -645,7 +645,7 @@ const UserMessageView = memo(function UserMessageView({
             <button
               type="button"
               ref={systemContextHeaderRef}
-              onClick={() => withSystemContextScrollLock(() => setShowSystemContext(!showSystemContext))}
+              onClick={() => withSystemContextScrollLock(() => setShowSystemContext(!showSystemContext), !showSystemContext)}
               className="flex items-center gap-1 text-[length:var(--fs-sm)] text-text-400 hover:text-text-300 transition-colors py-1 px-2 rounded hover:bg-bg-200"
             >
               <span>
@@ -1096,7 +1096,7 @@ const ToolGroup = memo(function ToolGroup({
             <button
               type="button"
               ref={stepsHeaderRef}
-              onClick={() => withStepsScrollLock(() => setExpanded(!expanded))}
+              onClick={() => withStepsScrollLock(() => setExpanded(!expanded), !expanded)}
               className="flex w-full items-baseline rounded-md py-1 text-left hover:bg-bg-200/30 transition-colors"
             >
               <span className="text-[length:var(--fs-sm)] leading-5">
@@ -1128,7 +1128,7 @@ const ToolGroup = memo(function ToolGroup({
             <button
               type="button"
               ref={stepsHeaderRef}
-              onClick={() => withStepsScrollLock(() => setExpanded(!expanded))}
+              onClick={() => withStepsScrollLock(() => setExpanded(!expanded), !expanded)}
               className="flex items-center gap-1.5 py-1.5 text-text-400 text-[length:var(--fs-base)] hover:text-text-200 hover:bg-bg-200/30 rounded-md transition-colors"
             >
               <span className="inline-flex w-[14px] items-center justify-center shrink-0">

--- a/src/features/message/parts/MessageErrorView.tsx
+++ b/src/features/message/parts/MessageErrorView.tsx
@@ -53,7 +53,7 @@ export const MessageErrorView = memo(function MessageErrorView({ error, stateKey
       <div
         ref={headerRef}
         className={`flex items-center gap-2 ${hasDetails ? 'cursor-pointer' : ''}`}
-        onClick={() => hasDetails && withScrollLock(() => setExpanded(!expanded))}
+        onClick={() => hasDetails && withScrollLock(() => setExpanded(!expanded), !expanded)}
       >
         <AlertCircleIcon className={`w-4 h-4 ${colorClass} flex-shrink-0`} />
         <span className={`text-[length:var(--fs-base)] ${colorClass} flex-1 min-w-0 truncate`}>{title}</span>

--- a/src/features/message/parts/ReasoningPartView.tsx
+++ b/src/features/message/parts/ReasoningPartView.tsx
@@ -33,7 +33,7 @@ export const ReasoningPartView = memo(function ReasoningPartView({ part, isStrea
   const summaryMeasureRef = useRef<HTMLSpanElement>(null)
   const [summaryOverflow, setSummaryOverflow] = useState(false)
   const toggleExpanded = useCallback(() => {
-    withScrollLock(() => setExpanded(!expanded))
+    withScrollLock(() => setExpanded(!expanded), !expanded)
   }, [expanded, setExpanded, withScrollLock])
 
   const collapsedPreview = useMemo(() => (displayText || '').replace(/\s+/g, ' ').trim(), [displayText])

--- a/src/features/message/parts/SubtaskPartView.tsx
+++ b/src/features/message/parts/SubtaskPartView.tsx
@@ -50,7 +50,7 @@ export const SubtaskPartView = memo(function SubtaskPartView({ part }: SubtaskPa
       <div
         ref={headerRef}
         className="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-bg-200/30 transition-colors"
-        onClick={() => withScrollLock(() => setExpanded(!expanded))}
+        onClick={() => withScrollLock(() => setExpanded(!expanded), !expanded)}
       >
         {/* Status indicator */}
         <div

--- a/src/features/message/parts/SystemPartViews.tsx
+++ b/src/features/message/parts/SystemPartViews.tsx
@@ -29,7 +29,7 @@ export const RetryPartView = memo(function RetryPartView({ part }: RetryPartView
       <button
         type="button"
         ref={headerRef}
-        onClick={() => withScrollLock(() => setExpanded(!expanded))}
+        onClick={() => withScrollLock(() => setExpanded(!expanded), !expanded)}
         aria-expanded={expanded}
         className="flex w-full items-center gap-2 bg-transparent border-none p-0 text-left"
       >
@@ -114,7 +114,7 @@ export const PatchPartView = memo(function PatchPartView({ part }: PatchPartView
       <button
         type="button"
         ref={headerRef}
-        onClick={() => withScrollLock(() => setExpanded(!expanded))}
+        onClick={() => withScrollLock(() => setExpanded(!expanded), !expanded)}
         aria-expanded={expanded}
         className="flex h-8 w-full items-center gap-2 px-3 text-left bg-transparent border-none hover:bg-bg-200/30 transition-colors"
       >

--- a/src/features/message/parts/ToolPartView.tsx
+++ b/src/features/message/parts/ToolPartView.tsx
@@ -133,7 +133,7 @@ export const ToolPartView = memo(function ToolPartView({
   // 展开即挂 body：默认展开的工具 header/body 同帧，不再先 header 后 body
   const shouldRenderBody = useDelayedRender(keepMounted)
   const toggleExpanded = useCallback(() => {
-    withScrollLock(() => setExpanded(!expanded))
+    withScrollLock(() => setExpanded(!expanded), !expanded)
   }, [expanded, setExpanded, withScrollLock])
 
   useEffect(() => {

--- a/src/features/message/tools/renderers/TaskRenderer.tsx
+++ b/src/features/message/tools/renderers/TaskRenderer.tsx
@@ -101,7 +101,7 @@ export const TaskRenderer = memo(function TaskRenderer({ part, onFullscreenChang
           status={state.status}
           expanded={expanded}
           headerRef={headerRef}
-          onToggle={() => withScrollLock(() => setExpanded(!expanded))}
+          onToggle={() => withScrollLock(() => setExpanded(!expanded), !expanded)}
           sessionId={targetSessionId}
           onStop={isRunning ? handleStop : undefined}
         />

--- a/src/features/message/tools/renderers/TodoRenderer.tsx
+++ b/src/features/message/tools/renderers/TodoRenderer.tsx
@@ -48,7 +48,7 @@ function TodoList({ todos, stateKey }: { todos: TodoItem[]; stateKey: string }) 
       <div
         ref={headerRef}
         className="flex items-center justify-between px-3 h-8 bg-bg-200/50 hover:bg-bg-200 cursor-pointer select-none transition-colors"
-        onClick={() => withScrollLock(() => setCollapsed(!collapsed))}
+        onClick={() => withScrollLock(() => setCollapsed(!collapsed), collapsed)}
       >
         <div className="flex items-center gap-2">
           <span className={`text-text-400 transition-transform duration-200 ${collapsed ? '-rotate-90' : ''}`}>

--- a/src/hooks/AutoScrollContext.ts
+++ b/src/hooks/AutoScrollContext.ts
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react'
+
+/**
+ * 让 message tree 里的子组件（如 disclosure widget）能通知 ChatArea：
+ * 「用户做了某个会停止贴底跟随的操作」（展开/折叠工具调用、跳转到消息等）。
+ *
+ * 由 ChatArea 提供，consume 方通过 useAutoScrollIntent() 拿到 pause。
+ * Context 值应当 stable（pause 是 useCallback），不会引起消费方 re-render。
+ */
+export interface AutoScrollContextValue {
+  pause: () => void
+}
+
+const AutoScrollContext = createContext<AutoScrollContextValue | null>(null)
+
+export const AutoScrollProvider = AutoScrollContext.Provider
+
+export function useAutoScrollIntent(): AutoScrollContextValue | null {
+  return useContext(AutoScrollContext)
+}

--- a/src/hooks/useDisclosureScrollLock.ts
+++ b/src/hooks/useDisclosureScrollLock.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, type RefCallback } from 'react'
 import { lockScrollAroundAnchor, type LockScrollAroundAnchorOptions } from '../utils/scrollUtils'
+import { useAutoScrollIntent } from './AutoScrollContext'
 
 /**
  * 折叠/展开时把 header 钉在视口原位置。
@@ -7,13 +8,19 @@ import { lockScrollAroundAnchor, type LockScrollAroundAnchorOptions } from '../u
  * 用法：
  * - rootRef 挂在整块折叠容器（观察高度变化）
  * - headerRef 挂在点击条 / 标题
- * - 用户切换状态前调用 withScrollLock(() => setExpanded(...))
+ * - 用户切换状态前调用 withScrollLock(() => setExpanded(...), expanding)
+ *
+ * expanding=true（展开）时同时通知 AutoScrollContext 停止贴底跟随 ——
+ * 用户主动展开表示要停下来看内容，不应被流式拉走。
+ * expanding=false（折叠）时不改变跟随状态 —— 折叠只是收起已看过的内容，
+ * 不表达「我要停下来读」的意图。
  */
 export function useDisclosureScrollLock(options?: LockScrollAroundAnchorOptions) {
   const rootNodeRef = useRef<HTMLElement | null>(null)
   const headerNodeRef = useRef<HTMLElement | null>(null)
   const unlockRef = useRef<(() => void) | null>(null)
   const optionsRef = useRef(options)
+  const autoScroll = useAutoScrollIntent()
 
   useEffect(() => {
     optionsRef.current = options
@@ -34,14 +41,19 @@ export function useDisclosureScrollLock(options?: LockScrollAroundAnchorOptions)
     headerNodeRef.current = node
   }, [])
 
-  const withScrollLock = useCallback((action: () => void) => {
+  /**
+   * @param action 实际切换状态的回调
+   * @param expanding 是否是「展开」操作（true=展开→停止跟随；false=折叠→不动状态）
+   */
+  const withScrollLock = useCallback((action: () => void, expanding: boolean) => {
     unlockRef.current?.()
     unlockRef.current = lockScrollAroundAnchor(headerNodeRef.current, {
       observe: rootNodeRef.current,
       ...optionsRef.current,
     })
+    if (expanding) autoScroll?.pause()
     action()
-  }, [])
+  }, [autoScroll])
 
   return { rootRef, headerRef, withScrollLock }
 }

--- a/src/lib/overlayScrollbar.ts
+++ b/src/lib/overlayScrollbar.ts
@@ -26,6 +26,18 @@ const TRACK_PAD = 8
 const MIN_THUMB = 32
 const FADE_MS = 800
 
+/**
+ * 拖拽自绘 thumb 时，在 vp 上广播 dragstart / dragend。
+ * useAutoScroll 监听这两个事件来设置/清除 userScrolled，
+ * 否则拖拽 thumb 改了 scrollTop 却没表达「停止跟随」，
+ * 会被 handleScroll 的 drift 自愈立刻拉回底部 → 滚动条拖不动。
+ */
+export const OS_DRAG_START = 'os-scroll-dragstart'
+export const OS_DRAG_END = 'os-scroll-dragend'
+function emitOsDrag(vp: HTMLElement, type: string) {
+  vp.dispatchEvent(new CustomEvent(type, { bubbles: true }))
+}
+
 // ── 方向判断 ────────────────────────────────────────────
 
 /** 带 no-scrollbar / scrollbar-none 的元素故意不要滚动条，跳过 */
@@ -159,6 +171,7 @@ function createAxisThumb(axis: 'v' | 'h', vp: HTMLElement, parent: HTMLElement):
     dragging = true
     thumb.classList.add('os-dragging')
     thumb.setPointerCapture(e.pointerId)
+    emitOsDrag(vp, OS_DRAG_START)
 
     const startPos = axis === 'v' ? e.clientY : e.clientX
     const startScroll = axis === 'v' ? vp.scrollTop : vp.scrollLeft
@@ -182,6 +195,7 @@ function createAxisThumb(axis: 'v' | 'h', vp: HTMLElement, parent: HTMLElement):
       thumb.removeEventListener('pointermove', onMove)
       thumb.removeEventListener('pointerup', onUp)
       scheduleFade()
+      emitOsDrag(vp, OS_DRAG_END)
     }
 
     thumb.addEventListener('pointermove', onMove)


### PR DESCRIPTION
## 背景

这是 OpenCodeUI chat 滚动跟随系统的一次完整重写尝试。基于 v0.6.34 (`main` HEAD `c49fb49f`)。原实现基于 `markAuto` / `isAuto` 时间戳 token，几类反复出现的 bug 猜测都是因为这套机制：

- 流式输出中无故退出贴底
- 展开工具调用 / thinking block 后被拉回底部
- 小幅 wheel-up 退不出跟随
- 选中文字 → 取消选中 → 状态被错误改变

`scroll` 事件没有 JS 可见的输入层前驱 —— layout clamp、viewport resize、find-in-page、history restoration 都会 fire scroll 事件但没有任何用户手势。感觉这类场景里反推机制不可能 100% 准确。

## 三种实现并列对比

### A. OpenCodeUI 当前实现（`useAutoScroll.ts`）

核心：markAuto / isAuto 时间戳。

```
el.scrollTop = max
markAuto(el)              // 记录 top + now()

scroll 事件 → handleScroll:
  isAuto(el)?              // (Date.now() - token.time < 1500ms) && (|scrollTop - token.top| < 2)
    yes → ignore           // 程序触发，不动
    no  → stop()           // 用户滚动，停跟随
```

5 处显式 `markAuto` 调用点（scrollToFn、resizeItem 微任务、pinToBottom、scrollToLastMessage、imperative handle）。4 套阈值（10/60/150/80）。双门控（userScrolledRef && prevState.bottom）。

### B. OpenCode 上游实现（`packages/ui/src/hooks/create-auto-scroll.ts`）

OpenCode 同时保留了 markAuto 系统并叠加了 `scrollGesture` 系统：

```
scrollGestureWindowMs = 250

用户输入（wheel / touch / pointer / key）：
  markScrollGesture(target)
    ↓
  最近的 scrollGesture 时间戳

scroll 事件 → handleScroll:
  if hasScrollGesture(): stop()
  else if isAuto(): scrollToBottom()
  else: stop()
```

OpenCode 的 `markBoundaryGesture` 是个有意思的设计：嵌套块内滚动是私有的，只有溢出时才把意图上传给外层 chat：

```
shouldMarkBoundaryGesture(delta, scrollTop, scrollHeight, clientHeight):
  if delta < 0: return scrollTop + delta <= 0    // 上滚到顶
  return delta > max - scrollTop                  // 下滚到底
```

OpenCode 配套的 `data-scrollable` 静态属性标记嵌套块，`normalizeWheelDelta` 处理 pixel/line/page 三种 deltaMode。

### C. 这个 PR 的尝试

input-event-driven 单系统：用户意图在事件源头直接声明，scroll 事件**根本不参与**状态判定。

```
userScrolled (single ref + state)
  ↓ ↑ 由用户输入直接设置
  ↓
输入事件（capture phase, native listener）：
  wheel / touchstart / touchmove / touchend /
  pointerdown / pointerup / keydown /
  OS_DRAG_START / OS_DRAG_END / selectionchange

scroll 事件：
  只负责 drift pin（用户在跟随时排 rAF 写回底部）
  + recovery window 内的 atBottom 完成恢复
```

`scroll` 事件永远不直接清 userScrolled，除非在用户显式向下输入打开的 500ms 恢复窗口内（解决 iOS momentum / 触屏边界偏差）。

### 三方对比

| 维度 | OpenCodeUI 当前 | OpenCode | 本 PR |
|---|---|---|---|
| 意图来源 | scroll 事件反推 | 输入 + scroll 事件反推 | 仅输入 |
| 嵌套块 | 不处理 | markBoundaryGesture | markBoundaryGesture（沿用） |
| 嵌套块检测 | 运行时 getComputedStyle | `data-scrollable` 静态 | `data-scrollable` 静态（沿用） |
| wheel delta | 原值 | normalize | normalize（沿用） |
| wheel down | tryRecover 即时 | tryRecover 即时 | mark + handleScroll 窗口 |
| selection | onClick 检查 | onClick 检查 | selectionchange 监听 |
| 触屏 | 简单 stopFollow | React handler | 方向感知 |
| 状态机 | userScrolled + markAuto + prevState | userScrolled + scrollGesture + markAuto | userScrolled + recovery window |

## 与 OpenCode 上游的差异（保留 vs 改动）

**沿用 OpenCode**：
- `data-scrollable` 静态属性（加在 ScrollArea / CodeBlock / DiffViewer / Markdown 代码预览）
- `shouldMarkBoundaryGesture` 嵌套块边界溢出检测
- `normalizeWheelDelta` 处理 pixel/line/page
- `withScrollLock(action, expanding)` 显式声明 expand/collapse
- AutoScrollContext 跨组件树连接 pause 信号

**和 OpenCode 不同**：

1. **删掉 markAuto**：OpenCode 双系统（markAuto + scrollGesture）我们只用一个。原因：markAuto 存在的意义是「程序写的 scroll 事件不该被当作用户输入」。但状态由输入事件直接设置，scroll 事件根本不参与状态判定，markAuto 没有存在的必要。

2. **wheel-down 开恢复窗口**：OpenCode 立即调 tryRecover 检查 atBottom。我们开 500ms 窗口让 iOS momentum 和触屏松手时差几 px 的情况也能完成恢复。

3. **selection 用 selectionchange 而非 onClick**：OpenCode 的 `handleInteraction` 只在 click 时检查（要等 mouseup）。`selectionchange` 能更早捕获「开始选」的意图。但加了判断：只对 empty → non-empty 起反应，clear 不动。

4. **触屏方向感知**（OpenCode 没有）：touchmove 跟踪 `touchMaxDownRef`，touchend 只在确实向下滚过 >10px 时才调 tryRecover。否则 tap 一下立即恢复，再松手就被 drift 自愈拉回去。

5. **toBottom 按钮由 userScrolled 驱动**（OpenCode 没有）：OpenCode 用位置阈值（60/150px）。我们用 userScrolled 状态反转。小幅 wheel-up 不动 scrollTop 时按钮仍要显示，因为 userScrolled=true（用户表达了停止意图）。

6. **OS_DRAG_START/END 自定义事件**（OpenCode 没有）：OpenCodeUI 自绘滚动条（overlayScrollbar）的 thumb 在父元素上 + stopPropagation，pointerdown 检测不到。我们让 overlayScrollbar 在 thumb 拖拽时广播 OS_DRAG_START/END 自定义事件。

## 为什么用单系统

OpenCode 双系统有两个 clock 协调：

- `autoTimer`: 程序 scroll 标记，1500ms TTL
- `ui.scrollGesture`: 用户输入标记，250ms 窗口

我们只有一个：recovery window（500ms）。理由：

- markAuto 想识别「程序写的 scroll 不该被当作用户输入」。但状态机根本不读 scroll 事件做判断，所以 markAuto 没有目标。
- scrollGesture 想用「最近 250ms 内有过用户手势」作为一种信号。我们每次输入事件直接调用 stopFollow / tryRecover，不需要中间时间戳。

代价：markAuto 的程序写入识别能力没了。比如程序调 `el.scrollTop = max` 后立即 fire scroll —— OpenCode 用 markAuto 忽略；我们直接信任 handleScroll 的 atBottom 判断（atBottom=true 就排 rAF pin 回去）。这是等效的，但路径不同。

## 修复的 bug

| Bug | 旧实现根因 | 新实现处理 |
|---|---|---|
| 流式中无故退出贴底 | scroll 事件无 JS 前驱场景误判 | 这些场景不匹配任何输入事件 |
| 展开工具/thinking 被拉回底 | lockScrollAroundAnchor 写 scrollTop 被当用户滚动 | disclosure 显式 expanding=true 才 stop |
| 小幅 wheel-up 退不出 | scroll 事件看到 atBottom=true 立刻清 userScrolled | scroll 事件不参与状态判定 |
| 选中/取消选中状态变化 | handleInteraction 笼统处理 | 只对 empty→non-empty 起反应，clear 不动 |
| 自绘滚动条拖拽没用 | pointerdown 检测不到 thumb | OS_DRAG_START/END 自定义事件 |
| 嵌套代码块内 wheel 误停 | markAuto 不理解嵌套容器边界 | boundary 检查（OpenCode 沿用） |

## 未解决的边界

- **recovery window 是启发式**：500ms 对慢设备可能不够，对快设备可能太长
- **iOS momentum 极端情况**：超慢 momentum 可能在窗口外完成；fallback 是点 toBottom 按钮
- **`data-scrollable` 漏标记**：新增嵌套滚动组件必须记得加，否则 fallback 到「嵌套块内 wheel 也算 chat 跟随」行为
- **OpenCode 的「scrollGesture 不区分方向」**：我们也用相同思路（markRecoverGesture 不区分方向）。但 OpenCode 还在边界外用 `hasScrollGesture()` 通用判定，我们是显式 stopFollow / tryRecover 两条路径。哪种更可扩展不确定。
- **测试覆盖度**：29 个集成测试覆盖核心状态转换。真实浏览器行为（capture phase 边界、native momentum、real getComputedStyle）仍需手测。


## 兼容性

- 删掉了 5 处 markAuto 调用点
- 删掉了 prevState.bottom 二次门控
- 删除了 `useAutoScroll.handleInteraction` / `handleWheel` / `markAuto` / `isAuto` API
- `useDisclosureScrollLock.withScrollLock` 是破坏性变更（加了第 2 个参数），所有 8 个调用点已更新
- `AutoScrollContext` 是新增，不破坏现有组件

## 文件

20 个文件改动（+1181/-139 行）：

```
新增：
  src/hooks/AutoScrollContext.ts                    (context + useAutoScrollIntent hook)
  src/features/chat/DESIGN.md                       (设计文档 + mermaid 序列图)
  src/features/chat/virtual/useAutoScroll.test.tsx  (29 集成测试)

重写：
  src/features/chat/virtual/useAutoScroll.ts        (320 行)

修改：
  src/hooks/useDisclosureScrollLock.ts              (withScrollLock 加 expanding 参数)
  src/features/chat/ChatArea.tsx                    (onFollowingChange callback)
  src/features/chat/ChatPane.tsx                    (isFollowing state)
  src/lib/overlayScrollbar.ts                       (OS_DRAG_START/END 事件)
  8 个 disclosure widget 调用点                      (ToolPartView / ReasoningPartView / ...)
  4 个嵌套滚动组件                                  (CodeBlock / DiffViewer / ...)
```

## 测试

- 602/602 passing（其中 29 个新的 useAutoScroll.test.tsx）
- `tsc -b` clean
- `eslint` clean
- 手测覆盖 11 个场景（见 DESIGN.md）

## 起点

基于 `main` (`c49fb49f`, v0.6.34)。单一 commit `refactor(chat): input-event-driven scroll-follow redesign`。