### PR TITLE
feat(chat): 用输入框上方的排队消息预览条替代占位消息

### DIFF
--- a/src/features/chat/ChatPane.tsx
+++ b/src/features/chat/ChatPane.tsx
@@ -18,6 +18,7 @@ import { useFolderProjectDrop } from './useFolderProjectDrop'
 import { FolderProjectDropOverlay } from './FolderProjectDropOverlay'
 import { useChatSession, useModels, useModelSelection } from '../../hooks'
 import { useServerStore } from '../../hooks/useServerStore'
+import { followupQueueStore } from '../../store/followupQueueStore'
 import { useCancelHint } from '../../hooks/useCancelHint'
 import { InlineToolRequestContext, type InlineToolRequestContextValue } from './InlineToolRequestContext'
 import { ChatViewportProvider, canUseSplitPane, useChatViewportMaybe, type ChatViewportValue } from './chatViewport'
@@ -274,6 +275,10 @@ export const ChatPane = memo(function ChatPane({
     handleQuestionReject,
     isReplying,
 
+    queuedFollowups,
+    queuedFollowupFailedId,
+    queuedFollowupSendingId,
+
     loadMoreHistory,
     handleRedoAll,
     clearRevert,
@@ -282,6 +287,7 @@ export const ChatPane = memo(function ChatPane({
     registerInputBox,
 
     handleSend,
+    handleSendQueuedNow,
     handleAbort,
     handleCommand,
     handleUndoWithAnimation,
@@ -303,6 +309,25 @@ export const ChatPane = memo(function ChatPane({
     navigateToSession,
     navigateHome,
   })
+
+  const handleRemoveQueuedMessage = useCallback(
+    (id: string) => {
+      if (routeSessionId) {
+        followupQueueStore.remove(routeSessionId, id)
+      }
+    },
+    [routeSessionId],
+  )
+
+  const handleCancelFailedQueuedMessage = useCallback(
+    (id: string) => {
+      if (routeSessionId) {
+        followupQueueStore.clearFailed(routeSessionId)
+        followupQueueStore.remove(routeSessionId, id)
+      }
+    },
+    [routeSessionId],
+  )
 
   const messageView = useMemo(() => ({ sessionId: routeSessionId, messages }), [routeSessionId, messages])
   const deferredMessageView = useDeferredValue(messageView)
@@ -939,6 +964,12 @@ export const ChatPane = memo(function ChatPane({
                 }
               : undefined
           }
+          queuedItems={queuedFollowups}
+          queuedFailedId={queuedFollowupFailedId}
+          queuedSendingId={queuedFollowupSendingId}
+          onQueuedRemove={handleRemoveQueuedMessage}
+          onQueuedCancelFailed={handleCancelFailedQueuedMessage}
+          onQueuedSendNow={handleSendQueuedNow}
         />
       </div>
 

--- a/src/features/chat/InputBox.tsx
+++ b/src/features/chat/InputBox.tsx
@@ -15,7 +15,9 @@ import { InputToolbar } from './input/InputToolbar'
 import type { ModelSelectorHandle } from './ModelSelector'
 import { InputFooter } from './input/InputFooter'
 import { FloatingActions, CollapsedCapsule } from './input/InputActions'
+import { QueuedMessagesBar } from './input/QueuedMessagesBar'
 import { useMobileCollapse } from './input/useMobileCollapse'
+import type { QueuedFollowupDraft } from '../../store/followupQueueStore'
 import { useAttachmentRail } from './input/useAttachmentRail'
 import { useInputHistory } from './input/useInputHistory'
 import {
@@ -159,6 +161,13 @@ export interface InputBoxProps {
   // Collapsed dialog capsules
   collapsedPermission?: CollapsedDialogInfo
   collapsedQuestion?: CollapsedDialogInfo
+  // Queued messages — data + callbacks
+  queuedItems?: QueuedFollowupDraft[]
+  queuedFailedId?: string
+  queuedSendingId?: string
+  onQueuedRemove?: (id: string) => void
+  onQueuedCancelFailed?: (id: string) => void
+  onQueuedSendNow?: (id: string) => void
 }
 
 // ============================================
@@ -201,6 +210,12 @@ function InputBoxComponent({
   onScrollToBottom,
   collapsedPermission,
   collapsedQuestion,
+  queuedItems = [],
+  queuedFailedId,
+  queuedSendingId,
+  onQueuedRemove,
+  onQueuedCancelFailed,
+  onQueuedSendNow,
 }: InputBoxProps) {
   const { t } = useTranslation('chat')
   // 合并文件能力：优先用 fileCapabilities，回退到 supportsImages
@@ -1251,6 +1266,7 @@ function InputBoxComponent({
               onExpand={handleExpandInput}
               showScrollToBottom={showScrollToBottom}
               onScrollToBottom={onScrollToBottom}
+              queuedCount={queuedItems.length}
             />
           )}
 
@@ -1263,6 +1279,20 @@ function InputBoxComponent({
                 : 'relative opacity-100 scale-100'
             }`}
           >
+            {/* Queued Messages Bar — 在输入框展开时显示 */}
+            {!isCollapsed && queuedItems.length > 0 && (
+              <div className="pb-2">
+                <QueuedMessagesBar
+                  items={queuedItems}
+                  failedId={queuedFailedId}
+                  sendingId={queuedSendingId}
+                  onRemove={onQueuedRemove!}
+                  onCancelFailed={onQueuedCancelFailed!}
+                  onSendNow={onQueuedSendNow!}
+                />
+              </div>
+            )}
+
             {/* @ Mention Menu */}
             <MentionMenu
               ref={mentionMenuRef}

--- a/src/features/chat/input/InputActions.tsx
+++ b/src/features/chat/input/InputActions.tsx
@@ -128,12 +128,14 @@ interface CollapsedCapsuleProps {
   onExpand: () => void
   showScrollToBottom?: boolean
   onScrollToBottom?: () => void
+  queuedCount?: number
 }
 
 export const CollapsedCapsule = memo(function CollapsedCapsule({
   onExpand,
   showScrollToBottom,
   onScrollToBottom,
+  queuedCount = 0,
 }: CollapsedCapsuleProps) {
   const { t } = useTranslation(['chat', 'common'])
   return (
@@ -145,6 +147,11 @@ export const CollapsedCapsule = memo(function CollapsedCapsule({
       >
         <ArrowUpIcon size={14} />
         <span className="text-[length:var(--fs-xs)]">{t('inputActions.reply')}</span>
+        {queuedCount > 0 && (
+          <span className="ml-0.5 px-1.5 py-0.5 rounded-full bg-accent-main-100/15 text-accent-main-100 text-[length:var(--fs-xxs)] font-medium leading-none">
+            {queuedCount}
+          </span>
+        )}
       </button>
       {showScrollToBottom && <ScrollToBottomButton onClick={onScrollToBottom} />}
     </div>

--- a/src/features/chat/input/QueuedMessagesBar.tsx
+++ b/src/features/chat/input/QueuedMessagesBar.tsx
@@ -1,0 +1,158 @@
+import { memo, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { SendIcon, ClockIcon, CloseIcon } from '../../../components/Icons'
+import { usePresence } from '../../../hooks'
+import type { QueuedFollowupDraft } from '../../../store/followupQueueStore'
+
+// ============================================
+// QueuedMessagesBar — 输入框上方的排队消息预览条
+// 宽度与输入框一致，每条消息独立一行，文本溢出截断 + hover 展示全文
+// ============================================
+
+interface QueuedMessagesBarProps {
+  items: QueuedFollowupDraft[]
+  failedId?: string
+  sendingId?: string
+  onRemove: (id: string) => void
+  onCancelFailed: (id: string) => void
+  onSendNow: (id: string) => void
+}
+
+/** 多行文本压缩为单行，供 title tooltip 使用 */
+function tooltipText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
+const QueuedMessageRow = memo(function QueuedMessageRow({
+  item,
+  isFailed,
+  isSending,
+  onRemove,
+  onCancelFailed,
+  onSendNow,
+}: {
+  item: QueuedFollowupDraft
+  isFailed: boolean
+  isSending: boolean
+  onRemove: (id: string) => void
+  onCancelFailed: (id: string) => void
+  onSendNow: (id: string) => void
+}) {
+  const { t } = useTranslation('chat')
+  const { shouldRender, ref } = usePresence<HTMLDivElement>(true, {
+    from: { opacity: 0, transform: 'translateY(-4px)' },
+    to: { opacity: 1, transform: 'translateY(0)' },
+    duration: 0.2,
+  })
+
+  const handleRemove = useCallback(() => onRemove(item.id), [item.id, onRemove])
+  const handleCancelFailed = useCallback(() => onCancelFailed(item.id), [item.id, onCancelFailed])
+  const handleSendNow = useCallback(() => onSendNow(item.id), [item.id, onSendNow])
+  const fullText = tooltipText(item.text)
+
+  if (!shouldRender) return null
+
+  return (
+    <div
+      ref={ref}
+      data-state={isFailed ? 'failed' : isSending ? 'sending' : 'pending'}
+      className={`
+        flex items-center gap-2 w-full px-3 py-1.5 text-[length:var(--fs-sm)]
+        transition-colors
+        ${isFailed
+          ? 'bg-danger-100/8 text-danger-100'
+          : isSending
+            ? 'bg-accent-main-100/8 text-text-200'
+            : 'hover:bg-bg-000/30 text-text-200'
+        }
+      `}
+    >
+      {/* 状态图标 */}
+      <span className="shrink-0">
+        {isSending ? (
+          <span className="inline-block w-3.5 h-3.5 rounded-full border-2 border-accent-main-100/30 border-t-accent-main-100 animate-spin" />
+        ) : (
+          <ClockIcon size={14} />
+        )}
+      </span>
+
+      {/* 消息文本 — 溢出截断，hover 展示全文 */}
+      <span
+        className="flex-1 min-w-0 truncate"
+        title={fullText}
+      >
+        {fullText}
+      </span>
+
+      {/* 附件标记 */}
+      {item.attachments.length > 0 && (
+        <span className="shrink-0 text-text-400 text-[length:var(--fs-xs)]">
+          📎{item.attachments.length}
+        </span>
+      )}
+
+      {/* agent 标记 */}
+      {item.agent && (
+        <span className="shrink-0 text-text-400 text-[length:var(--fs-xs)] bg-bg-300/50 rounded px-1">
+          {item.agent}
+        </span>
+      )}
+
+      {/* 失败标记 */}
+      {isFailed && (
+        <span className="shrink-0 text-danger-100 font-medium text-[length:var(--fs-xs)]">
+          {t('queuedMessages.failed')}
+        </span>
+      )}
+
+      {/* 立即发送按钮（仅排队中显示） */}
+      {!isFailed && !isSending && (
+        <button
+          type="button"
+          onClick={handleSendNow}
+          className="shrink-0 p-1 rounded hover:bg-accent-main-100/15 text-text-400 hover:text-accent-main-100 transition-colors"
+          aria-label={t('queuedMessages.sendNow')}
+        >
+          <SendIcon size={14} />
+        </button>
+      )}
+
+      {/* 删除/放弃按钮 */}
+      <button
+        type="button"
+        onClick={isFailed ? handleCancelFailed : handleRemove}
+        className="shrink-0 p-1 rounded hover:bg-bg-300/50 transition-colors opacity-60 hover:opacity-100 -mr-1"
+        aria-label={isFailed ? t('queuedMessages.cancelFailed') : t('queuedMessages.remove')}
+      >
+        <CloseIcon size={14} />
+      </button>
+    </div>
+  )
+})
+
+export const QueuedMessagesBar = memo(function QueuedMessagesBar({
+  items,
+  failedId,
+  sendingId,
+  onRemove,
+  onCancelFailed,
+  onSendNow,
+}: QueuedMessagesBarProps) {
+  if (items.length === 0) return null
+
+  return (
+    <div className="flex flex-col gap-px w-full glass border border-border-200/60 rounded-lg shadow-lg overflow-hidden">
+      {items.map(item => (
+        <QueuedMessageRow
+          key={item.id}
+          item={item}
+          isFailed={item.id === failedId}
+          isSending={item.id === sendingId}
+          onRemove={onRemove}
+          onCancelFailed={onCancelFailed}
+          onSendNow={onSendNow}
+        />
+      ))}
+    </div>
+  )
+})

--- a/src/hooks/useChatSession.ts
+++ b/src/hooks/useChatSession.ts
@@ -284,86 +284,6 @@ export function useChatSession({
     }
   }, [approvePendingOnFullAuto, fullAutoMode, pendingPermissionRequests, replyPermissionOnceAutomatically])
 
-  const buildLocalQueuedMessage = useCallback(
-    (input: {
-      sessionId: string
-      messageId: string
-      text: string
-      attachments: Attachment[]
-      agent?: string
-      model: { providerID: string; modelID: string; variant?: string }
-      createdAt: number
-    }): UIMessage => {
-      const parts: UIMessage['parts'] = [
-        {
-          id: `${input.messageId}:text`,
-          type: 'text',
-          text: input.text,
-          synthetic: false,
-          sessionID: input.sessionId,
-          messageID: input.messageId,
-        },
-      ]
-
-      for (const attachment of input.attachments) {
-        if (attachment.type === 'agent') {
-          parts.push({
-            id: attachment.id || `${input.messageId}:agent:${parts.length}`,
-            type: 'agent',
-            name: attachment.agentName || attachment.displayName,
-            source: attachment.textRange
-              ? {
-                  value: attachment.textRange.value,
-                  start: attachment.textRange.start,
-                  end: attachment.textRange.end,
-                }
-              : undefined,
-            sessionID: input.sessionId,
-            messageID: input.messageId,
-          })
-          continue
-        }
-
-        if (attachment.type !== 'file' && attachment.type !== 'folder') continue
-
-        parts.push({
-          id: attachment.id || `${input.messageId}:file:${parts.length}`,
-          type: 'file',
-          mime: attachment.mime || (attachment.type === 'folder' ? 'application/x-directory' : 'text/plain'),
-          filename: attachment.displayName,
-          url: attachment.url || '',
-          source: attachment.textRange
-            ? {
-                type: 'file',
-                path: attachment.relativePath || attachment.displayName,
-                text: {
-                  value: attachment.textRange.value,
-                  start: attachment.textRange.start,
-                  end: attachment.textRange.end,
-                },
-              }
-            : undefined,
-          sessionID: input.sessionId,
-          messageID: input.messageId,
-        })
-      }
-
-      return {
-        info: {
-          id: input.messageId,
-          sessionID: input.sessionId,
-          role: 'user',
-          time: { created: input.createdAt },
-          agent: input.agent || '',
-          model: input.model,
-        },
-        parts,
-        isStreaming: false,
-      }
-    },
-    [],
-  )
-
   // ============================================
   // SSE 事件回调（permission / question / scroll / idle / error / reconnect）
   // 每个 pane 都注册自己的 consumer，由 App 顶层统一建立 SSE 连接
@@ -742,7 +662,7 @@ export function useChatSession({
         !!routeSessionId && (queuedFollowups.length > 0 || (queueFollowupMessages && isSessionBusy))
 
       if (shouldQueueFollowup) {
-        const queued = followupQueueStore.enqueue({
+        followupQueueStore.enqueue({
           sessionId: routeSessionId,
           directory: effectiveDirectory || '',
           text: content,
@@ -755,17 +675,6 @@ export function useChatSession({
           variant: options?.variant,
           agent: options?.agent,
         })
-        messageStore.upsertLocalMessage(
-          buildLocalQueuedMessage({
-            sessionId: queued.sessionId,
-            messageId: queued.id,
-            text: queued.text,
-            attachments: queued.attachments,
-            agent: queued.agent,
-            model: queued.model,
-            createdAt: queued.createdAt,
-          }),
-        )
         return true
       }
 
@@ -790,7 +699,6 @@ export function useChatSession({
       queueFollowupMessages,
       isSessionBusy,
       effectiveDirectory,
-      buildLocalQueuedMessage,
       sendMessageNow,
     ],
   )
@@ -800,9 +708,6 @@ export function useChatSession({
       const draft = followupQueueStore.getItem(sessionId, draftId)
       if (!draft) return false
       if (!followupQueueStore.startSending(draft.sessionId, draft.id)) return false
-
-      // 发送前先移除占位消息，让 sendMessageNow 走和正常发送完全一样的路径
-      messageStore.removeMessage(draft.sessionId, draft.id)
 
       const ok = await sendMessageNow({
         sessionId: draft.sessionId,
@@ -826,11 +731,6 @@ export function useChatSession({
       } else {
         // 标记失败，阻塞后续队列项
         followupQueueStore.markFailed(draft.sessionId, draft.id)
-        // 移除剩余排队消息的本地占位，恢复队头到输入框
-        const remaining = followupQueueStore.getItems(draft.sessionId)
-        for (const item of remaining) {
-          messageStore.removeMessage(draft.sessionId, item.id)
-        }
         setRestoredContent({
           sessionId: draft.sessionId,
           content: {
@@ -847,6 +747,27 @@ export function useChatSession({
       return ok
     },
     [sendMessageNow],
+  )
+
+  // 立即发送排队消息（跳过队列检查，直接发送）
+  const handleSendQueuedNow = useCallback(
+    async (draftId: string) => {
+      if (!routeSessionId) return false
+      const draft = followupQueueStore.getItem(routeSessionId, draftId)
+      if (!draft) return false
+
+      followupQueueStore.remove(routeSessionId, draftId)
+
+      return sendMessageNow({
+        sessionId: routeSessionId,
+        content: draft.text,
+        attachments: draft.attachments,
+        model: { providerID: draft.model.providerID, modelID: draft.model.modelID },
+        options: { agent: draft.agent, variant: draft.variant },
+        directory: draft.directory,
+      })
+    },
+    [routeSessionId, sendMessageNow],
   )
 
   useEffect(() => {
@@ -938,6 +859,8 @@ export function useChatSession({
   // Abort handler
   const handleAbort = useCallback(async () => {
     if (!routeSessionId) return
+    // 放弃当前回复时清空队列，排队消息不应继续发送
+    followupQueueStore.clearSession(routeSessionId)
     try {
       const directory = sessionDirectory || currentDirectory
       await abortSession(routeSessionId, directory)
@@ -1163,6 +1086,7 @@ export function useChatSession({
     pendingQuestionRequests,
     queuedFollowups,
     queuedFollowupSendingId,
+    queuedFollowupFailedId,
     handlePermissionReply,
     handleQuestionReply,
     handleQuestionReject,
@@ -1179,6 +1103,7 @@ export function useChatSession({
 
     // Handlers
     handleSend,
+    handleSendQueuedNow,
     handleAbort,
     handleCommand,
     handleUndoWithAnimation,

--- a/src/locales/en/chat.json
+++ b/src/locales/en/chat.json
@@ -192,6 +192,14 @@
     "cacheRW": "Cache (r/w)",
     "rawMessages": "Raw Messages"
   },
+  "queuedMessages": {
+    "count": "{{count}} queued",
+    "sending": "Sending…",
+    "failed": "Failed",
+    "remove": "Remove from queue",
+    "cancelFailed": "Dismiss",
+    "sendNow": "Send now"
+  },
   "hints": {
     "pressEscAgain": "Press <1>Esc</1> again to stop",
     "autoApproveAll": "Auto-approve: all sessions",

--- a/src/locales/zh-CN/chat.json
+++ b/src/locales/zh-CN/chat.json
@@ -192,6 +192,14 @@
     "cacheRW": "缓存 (读/写)",
     "rawMessages": "原始消息"
   },
+  "queuedMessages": {
+    "count": "{{count}} 条排队中",
+    "sending": "发送中…",
+    "failed": "发送失败",
+    "remove": "从队列移除",
+    "cancelFailed": "放弃",
+    "sendNow": "立即发送"
+  },
   "hints": {
     "pressEscAgain": "再按一次 <1>Esc</1> 停止",
     "autoApproveAll": "自动放行：全部会话",


### PR DESCRIPTION
#### 背景

之前开启"后续消息排队"后，用户在 AI 生成中发送消息时，队列会往 `messageStore` 里插入一条 `UserMessageView` 占位消息——和真实已发送的消息外观完全一样。用户无法分辨"已发送等回复"还是"还在排队没发出去"。

#### 改动

将隐形的占位消息方案替换为**输入框上方的排队消息预览条**。排队消息留在队列中，只有在真正发送后才出现在聊天区。

**新增文件：**
- `src/features/chat/input/QueuedMessagesBar.tsx` — 输入框上方的排队消息预览条
  - 毛玻璃样式（`glass`），与项目其他悬浮层一致
  - 每条消息独立一行，文本溢出截断 + hover tooltip 展示全文
  - 状态指示：排队中（⏱）、发送中（旋转动画）、失败（红色标记）
  - **立即发送**按钮，跳过队列直接发送
  - 删除按钮（×），可取消排队或放弃失败项
  - 入场动画（`usePresence`）

**`src/hooks/useChatSession.ts`：**
- 移除 `buildLocalQueuedMessage`（~80 行占位消息构造逻辑）
- 移除入队时的 `messageStore.upsertLocalMessage` 调用（不再往消息列表塞假消息）
- 移除 `sendQueuedFollowup` 中的 `messageStore.removeMessage` 清理
- 新增 `handleSendQueuedNow`——立即从队列移除并直接走 `sendMessageNow`
- `handleAbort` 中增加 `followupQueueStore.clearSession`——中止生成同时清空队列

**`src/features/chat/ChatPane.tsx`** — 将排队相关 props 传入 `InputBox`

**`src/features/chat/InputBox.tsx`** — 在展开态渲染 `QueuedMessagesBar`，折叠态隐藏

**`src/features/chat/input/InputActions.tsx`** — `CollapsedCapsule` 新增排队计数 badge

**`src/locales/en|zh-CN/chat.json`** — 排队消息相关翻译

#### 效果

**折叠状态：**
```
         [↑ Reply ②]   [↓]           ← 只显示计数 badge
```

**展开状态：**
```
┌──────────────────────────────────────────┐
│ ⏱ Fix the test that should pass when… →×│ ← glass 毛玻璃预览条
│ ⏱ Add error handling for the new en… →×│
├──────────────────────────────────────────┤
│ [textarea...                            ]│
│ [Agent] [Model]                 [Send]  │
└──────────────────────────────────────────┘
```