### PR TITLE
fix(chat): 折叠态输入框空白区域不应阻挡对聊天内容的点击/滚动`

### DIFF
--- a/src/features/chat/InputBox.tsx
+++ b/src/features/chat/InputBox.tsx
@@ -1205,7 +1205,9 @@ function InputBoxComponent({
   return (
     <div className="w-full">
       <div
-        className={`mx-auto max-w-3xl pointer-events-auto transition-[max-width] duration-300 ease-in-out ${isCompact ? 'px-2' : 'px-4'}`}
+        className={`mx-auto max-w-3xl transition-[max-width] duration-300 ease-in-out ${isCompact ? 'px-2' : 'px-4'} ${
+          isCollapsed ? 'pointer-events-none' : 'pointer-events-auto'
+        }`}
         style={{ paddingBottom: bottomDockPadding }}
       >
         <div

--- a/src/features/chat/input/InputActions.tsx
+++ b/src/features/chat/input/InputActions.tsx
@@ -17,7 +17,7 @@ export function PresenceItem({ show, children }: { show: boolean; children: Reac
   })
   if (!shouldRender) return null
   return (
-    <div ref={ref} className="shrink-0">
+    <div ref={ref} className="shrink-0 pointer-events-auto">
       {children}
     </div>
   )
@@ -37,7 +37,7 @@ export const ScrollToBottomButton = memo(function ScrollToBottomButton({ onClick
     <button
       type="button"
       onClick={onClick}
-      className="h-[32px] w-[32px] min-w-[32px] rounded-full bg-accent-main-100/10 border border-accent-main-100/20 backdrop-blur-md flex items-center justify-center text-accent-main-000 hover:bg-accent-main-100/20 transition-colors shrink-0"
+      className="h-[32px] w-[32px] min-w-[32px] rounded-full bg-accent-main-100/10 border border-accent-main-100/20 backdrop-blur-md flex items-center justify-center text-accent-main-000 hover:bg-accent-main-100/20 transition-colors shrink-0 pointer-events-auto"
       aria-label={t('inputActions.scrollToBottom')}
     >
       <ArrowDownIcon size={16} />
@@ -74,7 +74,7 @@ export const FloatingActions = memo(function FloatingActions({
   collapsedQuestion,
 }: FloatingActionsProps) {
   return (
-    <div className="flex items-center justify-center gap-2">
+    <div className="flex items-center justify-center gap-2 pointer-events-none">
       {/* Collapsed Permission Capsule */}
       <PresenceItem show={!!collapsedPermission}>
         {collapsedPermission && (
@@ -137,11 +137,11 @@ export const CollapsedCapsule = memo(function CollapsedCapsule({
 }: CollapsedCapsuleProps) {
   const { t } = useTranslation(['chat', 'common'])
   return (
-    <div className="flex items-center justify-center gap-2">
+    <div className="flex items-center justify-center gap-2 pointer-events-none">
       <button
         type="button"
         onClick={onExpand}
-        className="flex items-center gap-1.5 px-3 h-[32px] rounded-full glass border border-border-200/50 shadow-lg text-text-300 hover:text-text-200 hover:bg-bg-000 active:scale-95 transition-all"
+        className="flex items-center gap-1.5 px-3 h-[32px] rounded-full glass border border-border-200/50 shadow-lg text-text-300 hover:text-text-200 hover:bg-bg-000 active:scale-95 transition-all pointer-events-auto"
       >
         <ArrowUpIcon size={14} />
         <span className="text-[length:var(--fs-xs)]">{t('inputActions.reply')}</span>


### PR DESCRIPTION
### 问题

桌面端/移动端的折叠输入框（collapsed input dock）使用 `min-height: expandedHeight` + `justify-end` 来保持 `bottomPadding` 在收起/展开切换时稳定，避免虚拟列表 `paddingEnd` 抖动导致的滚动跳变。这是设计上必需的权衡。

副作用：当输入框折叠时，外层 `max-w-3xl` 容器的实际高度仍然等于收起前的输入框高度（约 100px+），但**可见的 capsule 只有底部约 32-40px**。中间约 60-70px 的空白区域：

- 视觉上不可见（容器背景透明，能看到后方的对话内容）
- 但继承了父元素的 `pointer-events-auto`，**捕获了所有的点击和滚动事件**

结果：用户收起输入框后，原本输入框下方的对话内容区域**无法滚动、无法选择文字**。

### 根因

CSS 的层叠规则——子元素设置 `pointer-events: none` 是不够的。父元素 `pointer-events: auto` 仍会在自己的整个边界上捕获事件。

### 修复方案

分层 pointer-events 方案：

| 层级 | 收起时 | 元素 |
|------|--------|------|
| 容器 | `pointer-events-none` | `mx-auto max-w-3xl`（关键修复）+ `FloatingActions`/`CollapsedCapsule` 根 flex |
| 交互叶子 | `pointer-events-auto` | `PresenceItem` 包装（permission/question 胶囊）、`CollapsedCapsule` Reply 按钮、`ScrollToBottomButton` |

展开态完全不受影响——`max-w-3xl` 在展开时仍是 `pointer-events-auto`。

### 改动

```
src/features/chat/InputBox.tsx           |  4 +++-
src/features/chat/input/InputActions.tsx | 10 +++++-----
2 files changed, 8 insertions(+), 6 deletions(-)
```

### 验证

- `tsc -b`：无类型错误
- `vitest`：3 个测试文件、17 个测试全绿（`InputBox.test.tsx`、`InputBoxAttachments.test.tsx`、`InputToolbar.test.tsx`）
- 手动验证：收起输入框后，原输入框区域的对话内容可正常滚动和选择；capsule 按钮和滚动按钮仍可正常点击

### 兼容性

- 桌面端 `desktopCollapsedInputDock` 与移动端 `enableCollapsedInputDock` 均覆盖
- `compact` 视图下行为一致
- 不影响任何展开态的现有行为
- 附带改进：展开态 `FloatingActions` 周围空白现在也是 click-through（之前因 inner div `pointer-events-auto` 占满）
