### PR TITLE
fix(reasoning): keep capsule scroll when scrolled up during streaming

### DIFF
--- a/src/features/message/parts/ReasoningPartView.tsx
+++ b/src/features/message/parts/ReasoningPartView.tsx
@@ -29,6 +29,7 @@ export const ReasoningPartView = memo(function ReasoningPartView({ part, isStrea
   const shouldRenderBody = useDelayedRender(expanded)
   const { rootRef, headerRef, withScrollLock } = useDisclosureScrollLock()
   const scrollAreaRef = useRef<HTMLDivElement>(null)
+  const isAtBottomRef = useRef(true)
   const summaryContainerRef = useRef<HTMLDivElement>(null)
   const summaryMeasureRef = useRef<HTMLSpanElement>(null)
   const [summaryOverflow, setSummaryOverflow] = useState(false)
@@ -76,10 +77,17 @@ export const ReasoningPartView = memo(function ReasoningPartView({ part, isStrea
     }
   }, [hasContent, isPartStreaming, setExpanded])
 
+  const handleCapsuleScroll = useCallback(() => {
+    const el = scrollAreaRef.current
+    if (!el) return
+    isAtBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 60
+  }, [])
+
   useEffect(() => {
     if (reasoningDisplayMode !== 'capsule') return
-    if (isPartStreaming && expanded && scrollAreaRef.current) {
-      scrollAreaRef.current.scrollTop = scrollAreaRef.current.scrollHeight
+    const el = scrollAreaRef.current
+    if (isPartStreaming && expanded && isAtBottomRef.current && el) {
+      el.scrollTop = el.scrollHeight
     }
   }, [displayText, isPartStreaming, expanded, reasoningDisplayMode])
 
@@ -277,7 +285,12 @@ export const ReasoningPartView = memo(function ReasoningPartView({ part, isStrea
       >
         <div className="min-h-0 min-w-0 overflow-hidden" style={{ clipPath: 'inset(0 -100% 0 -100%)' }}>
           {shouldRenderBody && (
-            <ScrollArea ref={scrollAreaRef} maxHeight={192} className="border-t border-border-300/20 bg-bg-200/30">
+            <ScrollArea
+              ref={scrollAreaRef}
+              maxHeight={192}
+              onScroll={handleCapsuleScroll}
+              className="border-t border-border-300/20 bg-bg-200/30"
+            >
               <div className="px-2 py-2 text-text-300 text-[length:var(--fs-sm)] font-mono whitespace-pre-wrap break-words overflow-x-hidden">
                 {displayText}
               </div>


### PR DESCRIPTION
Supersedes #127, narrowed to the one piece not already in `main`.

## Problem

During streaming, the **capsule reasoning** view (`reasoningDisplayMode === 'capsule'`) forces `scrollTop = scrollHeight` on every chunk. If the user scrolls up inside the capsule to read earlier output, the next token yanks them back to the bottom.

```ts
// ReasoningPartView.tsx — current
if (isPartStreaming && expanded && scrollAreaRef.current) {
  scrollAreaRef.current.scrollTop = scrollAreaRef.current.scrollHeight
}
```

## Fix

Match the 60px threshold already used by `BashRenderer` and `TaskRenderer` (`src/features/message/tools/renderers/`): only re-pin when the user is already within 60px of the bottom, otherwise leave their position untouched.

```ts
const handleCapsuleScroll = useCallback(() => {
  const el = scrollAreaRef.current
  if (!el) return
  isAtBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 60
}, [])

useEffect(() => {
  if (reasoningDisplayMode !== 'capsule') return
  const el = scrollAreaRef.current
  if (isPartStreaming && expanded && isAtBottomRef.current && el) {
    el.scrollTop = el.scrollHeight
  }
}, [displayText, isPartStreaming, expanded, reasoningDisplayMode])
```

`onScroll={handleCapsuleScroll}` is wired onto the `<ScrollArea>` (which forwards `onScroll` to its underlying scrollable div).

## Why this is the only change

#127 originally covered two blocks:
- **subagent `TaskRenderer` SubSessionView** — already in `main` (`src/features/message/tools/renderers/TaskRenderer.tsx:302`), so omitted here.
- **capsule reasoning** — this PR.

Using `useRef` (not `useState`) to match the sibling renderers and avoid re-renders on threshold crossing.

Verified: `typecheck` + `lint` clean, full suite `573/573` passing.