### PR TITLE
feat: 设置页新增一键重启服务功能

### DIFF
--- a/src/features/settings/components/RestartServerCard.tsx
+++ b/src/features/settings/components/RestartServerCard.tsx
@@ -1,0 +1,272 @@
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '../../../components/ui/Button'
+import { ConfirmDialog } from '../../../components/ui/ConfirmDialog'
+import { useServerStore } from '../../../hooks'
+import { serverStorage } from '../../../utils/perServerStorage'
+import { reconnectSSE } from '../../../api/events'
+import { SettingField, SettingsSection, settingsFieldClass } from './SettingsUI'
+import { detectSystemdActive, runRestartFlow, type RestartPhase, type RestartResult } from '../restartServer'
+
+const RESTART_COMMAND_KEY = 'restart-command'
+const RESTART_LOCK_PREFIX = 'restart-lock:'
+const RESTART_LOCK_TTL_MS = 60_000
+
+const PHASE_KEYS: Record<RestartPhase, string> = {
+  idle: '',
+  preflight: 'restart.phase.preflight',
+  executing: 'restart.phase.executing',
+  waiting: 'restart.phase.waiting',
+  recovered: 'restart.success',
+  failed: '',
+}
+
+function isRestartLocked(serverId: string): boolean {
+  try {
+    const raw = localStorage.getItem(`${RESTART_LOCK_PREFIX}${serverId}`)
+    if (!raw) return false
+    const timestamp = Number(raw)
+    if (!Number.isFinite(timestamp)) return false
+    return Date.now() - timestamp < RESTART_LOCK_TTL_MS
+  } catch {
+    return false
+  }
+}
+
+function setRestartLock(serverId: string): void {
+  try {
+    localStorage.setItem(`${RESTART_LOCK_PREFIX}${serverId}`, String(Date.now()))
+  } catch {
+    // ignore
+  }
+}
+
+function clearRestartLock(serverId: string): void {
+  try {
+    localStorage.removeItem(`${RESTART_LOCK_PREFIX}${serverId}`)
+  } catch {
+    // ignore
+  }
+}
+
+// ============================================
+// Restart Server Card
+// ============================================
+
+export function RestartServerCard() {
+  const { t } = useTranslation(['settings', 'common'])
+  const { activeServer } = useServerStore()
+  const serverId = activeServer?.id
+
+  const [command, setCommand] = useState(() => serverStorage.get(RESTART_COMMAND_KEY) ?? '')
+  const [phase, setPhase] = useState<RestartPhase>('idle')
+  const [output, setOutput] = useState('')
+  const [result, setResult] = useState<RestartResult | null>(null)
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [detecting, setDetecting] = useState(false)
+  const [errorKey, setErrorKey] = useState('')
+  const [pendingCommand, setPendingCommand] = useState('')
+
+  const cancelRequestedRef = useRef(false)
+  const runningRef = useRef(false)
+
+  const running = phase === 'preflight' || phase === 'executing' || phase === 'waiting'
+  runningRef.current = running
+
+  // 切换服务器时重新读取该服务器的重启命令
+  useEffect(() => {
+    if (runningRef.current) return
+    setCommand(serverStorage.get(RESTART_COMMAND_KEY) ?? '')
+    setPhase('idle')
+    setOutput('')
+    setResult(null)
+    setErrorKey('')
+  }, [serverId])
+
+  const handleCommandChange = (value: string) => {
+    setCommand(value)
+    serverStorage.set(RESTART_COMMAND_KEY, value)
+    setErrorKey('')
+  }
+
+  const handleRestartClick = async () => {
+    if (!activeServer) return
+    if (running || detecting) return
+    if (isRestartLocked(activeServer.id)) {
+      setErrorKey('restart.locked')
+      return
+    }
+
+    let cmd = command.trim()
+    if (!cmd) {
+      // 命令为空 → 自动识别 systemd 服务
+      setDetecting(true)
+      try {
+        const detected = await detectSystemdActive(activeServer)
+        if (detected) {
+          cmd = 'systemctl restart opencode.service'
+          setCommand(cmd)
+          serverStorage.set(RESTART_COMMAND_KEY, cmd)
+        } else {
+          setErrorKey('restart.emptyCommand')
+          return
+        }
+      } finally {
+        setDetecting(false)
+      }
+    }
+
+    setErrorKey('')
+    setPendingCommand(cmd)
+    setConfirmOpen(true)
+  }
+
+  const handleConfirm = async () => {
+    if (!activeServer || !pendingCommand) return
+    setConfirmOpen(false)
+
+    const server = {
+      id: activeServer.id,
+      name: activeServer.name,
+      url: activeServer.url,
+      auth: activeServer.auth,
+    }
+    cancelRequestedRef.current = false
+    setRestartLock(server.id)
+    setPhase('preflight')
+    setOutput('')
+    setResult(null)
+    setErrorKey('')
+
+    const res = await runRestartFlow({
+      server,
+      command: pendingCommand,
+      onPhase: p => setPhase(p),
+      onOutput: text => setOutput(prev => prev + text),
+      isCancelled: () => cancelRequestedRef.current,
+    })
+
+    clearRestartLock(server.id)
+    setResult(res)
+    setPhase(res.phase)
+    setOutput(res.output)
+    if (res.ok) {
+      // 服务已恢复，主动重连事件流（无订阅者时为空操作）
+      reconnectSSE()
+    }
+  }
+
+  const failureText = (res: RestartResult): string => {
+    switch (res.reason) {
+      case 'command-failed':
+        return t('restart.commandFailed', { code: res.doneCode ?? '?' })
+      case 'offline':
+        return t('restart.offline')
+      case 'unconfirmed':
+        return t('restart.unconfirmed')
+      case 'not-recovered':
+        return t('restart.notRecovered')
+      case 'timeout':
+        return t('restart.timeout')
+      case 'unauthorized':
+        return t('restart.unauthorized')
+      case 'cancelled':
+        return t('restart.cancelled')
+      case 'exec-error':
+        return t('restart.execError')
+      default:
+        return t('restart.timeout')
+    }
+  }
+
+  return (
+    <SettingsSection title={t('restart.title')} description={t('restart.desc')}>
+      <div className="space-y-3">
+        <SettingField label={t('restart.commandLabel')} description={t('restart.commandHelp')}>
+          <input
+            type="text"
+            value={command}
+            onChange={e => handleCommandChange(e.target.value)}
+            placeholder={t('restart.commandPlaceholder')}
+            disabled={running}
+            className={`${settingsFieldClass} font-mono`}
+            spellCheck={false}
+            autoComplete="off"
+          />
+        </SettingField>
+
+        <div className="flex items-center gap-2">
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={() => void handleRestartClick()}
+            isLoading={detecting || running}
+            disabled={!activeServer}
+          >
+            {t('restart.button')}
+          </Button>
+          {running && (
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => {
+                cancelRequestedRef.current = true
+              }}
+            >
+              {t('restart.cancel')}
+            </Button>
+          )}
+        </div>
+
+        {running && PHASE_KEYS[phase] && (
+          <p className="text-[length:var(--fs-xs)] text-text-300">{t(PHASE_KEYS[phase])}</p>
+        )}
+
+        {errorKey && <p className="text-[length:var(--fs-xs)] text-danger-100">{t(errorKey)}</p>}
+
+        {result && result.ok && <p className="text-[length:var(--fs-xs)] text-success-100">{t('restart.success')}</p>}
+
+        {result && !result.ok && (
+          <div className="rounded-md border border-danger-100/30 bg-danger-100/5 px-2.5 py-2 space-y-1.5">
+            <p className="text-[length:var(--fs-xs)] text-danger-100 leading-relaxed">{failureText(result)}</p>
+            {output && (
+              <>
+                <p className="text-[length:var(--fs-xs)] text-text-400">{t('restart.outputLabel')}</p>
+                <pre className="max-h-48 overflow-auto text-[length:var(--fs-xs)] font-mono text-text-200 whitespace-pre-wrap break-all leading-relaxed custom-scrollbar">
+                  {output}
+                </pre>
+              </>
+            )}
+          </div>
+        )}
+
+        {running && output && (
+          <pre className="max-h-48 overflow-auto text-[length:var(--fs-xs)] font-mono text-text-200 whitespace-pre-wrap break-all leading-relaxed custom-scrollbar">
+            {output}
+          </pre>
+        )}
+      </div>
+
+      <ConfirmDialog
+        isOpen={confirmOpen}
+        onClose={() => {
+          if (!running) setConfirmOpen(false)
+        }}
+        onConfirm={() => void handleConfirm()}
+        title={t('restart.confirmTitle')}
+        description={
+          <div className="space-y-2.5">
+            <p>{t('restart.confirmDesc', { name: activeServer?.name, url: activeServer?.url })}</p>
+            <pre className="rounded-md border border-border-200 bg-bg-100 px-2.5 py-2 text-[length:var(--fs-xs)] font-mono text-text-100 whitespace-pre-wrap break-all leading-relaxed">
+              {pendingCommand}
+            </pre>
+            <p className="text-[length:var(--fs-xs)] text-warning-100 leading-relaxed">{t('restart.warning')}</p>
+          </div>
+        }
+        confirmText={t('restart.confirmText')}
+        cancelText={t('restart.cancelText')}
+        variant="danger"
+      />
+    </SettingsSection>
+  )
+}

--- a/src/features/settings/components/ServersSettings.tsx
+++ b/src/features/settings/components/ServersSettings.tsx
@@ -14,6 +14,7 @@ import {
 import { useServerStore, useRouter } from '../../../hooks'
 import { messageStore } from '../../../store'
 import { settingsFieldClass, SettingsSection } from './SettingsUI'
+import { RestartServerCard } from './RestartServerCard'
 import type { ServerConfig, ServerHealth } from '../../../store/serverStore'
 
 const IPV4_PATTERN = /^(?:\d{1,3}\.){3}\d{1,3}$/
@@ -541,65 +542,69 @@ export function ServersSettings() {
   )
 
   return (
-    <SettingsSection
-      title={t('servers.connections')}
-      description={t('servers.connectionsDesc')}
-      actions={
-        <div className="flex items-center gap-2">
-          <button
-            onClick={checkAllHealth}
-            className="flex items-center justify-center w-7 h-7 rounded-md text-text-400 hover:text-text-200 hover:bg-bg-200/70 transition-colors"
-            title={t('common:refresh')}
-            aria-label={t('common:refresh')}
-          >
-            <RetryIcon size={14} />
-          </button>
-          <button
-            onClick={() => setAddingServer(true)}
-            disabled={addingServer}
-            className="h-7 px-2.5 rounded-md text-[length:var(--fs-sm)] font-medium text-accent-main-100 hover:bg-accent-main-100/10 transition-colors disabled:opacity-40"
-          >
-            {t('common:add')}
-          </button>
+    <>
+      <SettingsSection
+        title={t('servers.connections')}
+        description={t('servers.connectionsDesc')}
+        actions={
+          <div className="flex items-center gap-2">
+            <button
+              onClick={checkAllHealth}
+              className="flex items-center justify-center w-7 h-7 rounded-md text-text-400 hover:text-text-200 hover:bg-bg-200/70 transition-colors"
+              title={t('common:refresh')}
+              aria-label={t('common:refresh')}
+            >
+              <RetryIcon size={14} />
+            </button>
+            <button
+              onClick={() => setAddingServer(true)}
+              disabled={addingServer}
+              className="h-7 px-2.5 rounded-md text-[length:var(--fs-sm)] font-medium text-accent-main-100 hover:bg-accent-main-100/10 transition-colors disabled:opacity-40"
+            >
+              {t('common:add')}
+            </button>
+          </div>
+        }
+      >
+        <div className="space-y-1.5">
+          {orderedServers.map(s => (
+            <ServerItem
+              key={s.id}
+              server={s}
+              health={getHealth(s.id)}
+              isActive={activeServer?.id === s.id}
+              onSelect={() => handleSelectServer(s.id)}
+              onDelete={() => removeServer(s.id)}
+              onEdit={updates => {
+                const auth = updates.password
+                  ? { username: updates.username || 'opencode', password: updates.password }
+                  : undefined
+                updateServer(s.id, { name: updates.name, url: updates.url, auth })
+                void checkHealth(s.id)
+              }}
+              onCheckHealth={() => void checkHealth(s.id)}
+            />
+          ))}
+
+          {addingServer && (
+            <AddServerForm
+              onAdd={(n, u, user, pass) => {
+                const auth = pass ? { username: user || 'opencode', password: pass } : undefined
+                const s = addServer({ name: n, url: u, auth })
+                setAddingServer(false)
+                void checkHealth(s.id)
+              }}
+              onCancel={() => setAddingServer(false)}
+            />
+          )}
+
+          {servers.length === 0 && !addingServer && (
+            <div className="text-[length:var(--fs-md)] text-text-400 text-center py-8">{t('servers.noServersConfigured')}</div>
+          )}
         </div>
-      }
-    >
-      <div className="space-y-1.5">
-        {orderedServers.map(s => (
-          <ServerItem
-            key={s.id}
-            server={s}
-            health={getHealth(s.id)}
-            isActive={activeServer?.id === s.id}
-            onSelect={() => handleSelectServer(s.id)}
-            onDelete={() => removeServer(s.id)}
-            onEdit={updates => {
-              const auth = updates.password
-                ? { username: updates.username || 'opencode', password: updates.password }
-                : undefined
-              updateServer(s.id, { name: updates.name, url: updates.url, auth })
-              void checkHealth(s.id)
-            }}
-            onCheckHealth={() => void checkHealth(s.id)}
-          />
-        ))}
+      </SettingsSection>
 
-        {addingServer && (
-          <AddServerForm
-            onAdd={(n, u, user, pass) => {
-              const auth = pass ? { username: user || 'opencode', password: pass } : undefined
-              const s = addServer({ name: n, url: u, auth })
-              setAddingServer(false)
-              void checkHealth(s.id)
-            }}
-            onCancel={() => setAddingServer(false)}
-          />
-        )}
-
-        {servers.length === 0 && !addingServer && (
-          <div className="text-[length:var(--fs-md)] text-text-400 text-center py-8">{t('servers.noServersConfigured')}</div>
-        )}
-      </div>
-    </SettingsSection>
+      <RestartServerCard />
+    </>
   )
 }

--- a/src/features/settings/restartServer.test.ts
+++ b/src/features/settings/restartServer.test.ts
@@ -19,6 +19,8 @@ describe('buildPtyRestartScript', () => {
     expect(script).toContain('rc=$?')
     expect(script).toContain(`printf '\\n${RESTART_DONE_MARKER}:%s\\n' "$rc"`)
     expect(script).toContain('} 2>&1')
+    // 必须以换行结尾:交互 shell 中无尾换行的行不会被提交执行(真实环境验证过的 bug)
+    expect(script.endsWith('\n')).toBe(true)
 
     // 原始命令、rc 捕获、marker 打印、stderr 合并依次出现
     const commandIndex = script.indexOf('systemctl restart opencode')

--- a/src/features/settings/restartServer.test.ts
+++ b/src/features/settings/restartServer.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  RESTART_DONE_MARKER,
+  buildPtyRestartScript,
+  checkHealthOnce,
+  decideResult,
+  extractDoneCode,
+} from './restartServer'
+
+// ============================================
+// buildPtyRestartScript
+// ============================================
+
+describe('buildPtyRestartScript', () => {
+  it('wraps the original command with rc capture and done marker', () => {
+    const script = buildPtyRestartScript('systemctl restart opencode')
+
+    expect(script).toContain('{ systemctl restart opencode')
+    expect(script).toContain('rc=$?')
+    expect(script).toContain(`printf '\\n${RESTART_DONE_MARKER}:%s\\n' "$rc"`)
+    expect(script).toContain('} 2>&1')
+
+    // 原始命令、rc 捕获、marker 打印、stderr 合并依次出现
+    const commandIndex = script.indexOf('systemctl restart opencode')
+    const rcIndex = script.indexOf('rc=$?')
+    const markerIndex = script.indexOf(RESTART_DONE_MARKER)
+    const redirectIndex = script.indexOf('} 2>&1')
+    expect(commandIndex).toBeGreaterThan(-1)
+    expect(rcIndex).toBeGreaterThan(commandIndex)
+    expect(markerIndex).toBeGreaterThan(rcIndex)
+    expect(redirectIndex).toBeGreaterThan(markerIndex)
+  })
+})
+
+// ============================================
+// extractDoneCode
+// ============================================
+
+describe('extractDoneCode', () => {
+  it('extracts exit code from marker at end of output', () => {
+    const output = `systemctl restart opencode\n\n__OPENCODEUI_DONE__:0\n`
+    expect(extractDoneCode(output)).toBe(0)
+  })
+
+  it('extracts the last marker when multiple exist', () => {
+    const output = `a\n__OPENCODEUI_DONE__:1\nb\n__OPENCODEUI_DONE__:42`
+    expect(extractDoneCode(output)).toBe(42)
+  })
+
+  it('returns null when no marker present', () => {
+    expect(extractDoneCode('hello world')).toBeNull()
+  })
+
+  it('returns null for empty output', () => {
+    expect(extractDoneCode('')).toBeNull()
+  })
+})
+
+// ============================================
+// decideResult
+// ============================================
+
+describe('decideResult', () => {
+  const base = {
+    recovered: false,
+    observedOffline: false,
+    doneCode: null,
+    timedOut: false,
+    unauthorized: false,
+    cancelled: false,
+  }
+
+  it('succeeds when recovered after observing offline', () => {
+    const result = decideResult({ ...base, recovered: true, observedOffline: true, doneCode: 0 })
+    expect(result.ok).toBe(true)
+    expect(result.reason).toBeUndefined()
+  })
+
+  it('reports unconfirmed when recovered but no offline observed', () => {
+    const result = decideResult({ ...base, recovered: true, observedOffline: false, doneCode: 0 })
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('unconfirmed')
+  })
+
+  it('reports command-failed when doneCode is non-zero', () => {
+    const result = decideResult({ ...base, recovered: true, observedOffline: true, doneCode: 1 })
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('command-failed')
+  })
+
+  it('reports not-recovered when offline observed but timed out', () => {
+    const result = decideResult({ ...base, observedOffline: true, timedOut: true })
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('not-recovered')
+  })
+
+  it('reports timeout otherwise', () => {
+    const result = decideResult({ ...base, timedOut: true })
+    expect(result.ok).toBe(false)
+    expect(result.reason).toBe('timeout')
+  })
+
+  it('reports unauthorized', () => {
+    const result = decideResult({ ...base, unauthorized: true })
+    expect(result.reason).toBe('unauthorized')
+  })
+
+  it('reports cancelled', () => {
+    const result = decideResult({ ...base, cancelled: true })
+    expect(result.reason).toBe('cancelled')
+  })
+})
+
+// ============================================
+// checkHealthOnce
+// ============================================
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('checkHealthOnce', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns online when healthy json returned', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ healthy: true, version: 'v1.2.3' })))
+
+    const health = await checkHealthOnce({ url: 'http://server.test' })
+
+    expect(health.status).toBe('online')
+    expect(health.version).toBe('v1.2.3')
+  })
+
+  it('sends Basic auth header when credentials provided', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ healthy: true, version: 'v1' }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await checkHealthOnce({ url: 'http://server.test', auth: { username: 'opencode', password: 'secret' } })
+
+    const [input, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(input).toBe('http://server.test/global/health')
+    expect(init.headers).toEqual({ Authorization: `Basic ${btoa('opencode:secret')}` })
+  })
+
+  it('returns offline when fetch rejects', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
+
+    const health = await checkHealthOnce({ url: 'http://server.test' })
+
+    expect(health.status).toBe('offline')
+    expect(health.error).toBe('network down')
+  })
+
+  it('returns unauthorized on 401', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('nope', { status: 401 })))
+
+    const health = await checkHealthOnce({ url: 'http://server.test' })
+
+    expect(health.status).toBe('unauthorized')
+  })
+
+  it('returns error when server is not an OpenCode server', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ healthy: false })))
+
+    const health = await checkHealthOnce({ url: 'http://server.test' })
+
+    expect(health.status).toBe('error')
+  })
+
+  it('returns error for non-2xx status other than 401', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('boom', { status: 500 })))
+
+    const health = await checkHealthOnce({ url: 'http://server.test' })
+
+    expect(health.status).toBe('error')
+    expect(health.error).toBe('HTTP 500')
+  })
+})

--- a/src/features/settings/restartServer.ts
+++ b/src/features/settings/restartServer.ts
@@ -1,0 +1,521 @@
+// ============================================
+// Restart Server - 界面一键重启服务端
+//
+// 职责：
+// 1. 通过 PTY 在服务器上执行用户填写的重启命令
+// 2. 全程健康检查验证「断开 → 恢复」
+// 3. 提供可单测的纯函数（buildPtyRestartScript / extractDoneCode / decideResult）
+// ============================================
+
+import { makeBasicAuthHeader } from '../../store/serverStore'
+import type { ServerAuth, ServerHealth } from '../../store/serverStore'
+import { createPtySession, getPtyConnectUrl, removePtySession } from '../../api/pty'
+import { parsePtyFrame } from '../../utils/ptyProtocol'
+import { isTauri } from '../../utils/tauri'
+
+/**
+ * 命令完成标记。包装脚本在命令退出后打印：\n__OPENCODEUI_DONE__:<rc>\n
+ */
+export const RESTART_DONE_MARKER = '__OPENCODEUI_DONE__'
+
+/** 输出截断上限（32KB），超出后保留头部并在末尾追加截断提示 */
+const MAX_OUTPUT_BYTES = 32 * 1024
+const TRUNCATED_NOTE = '\n[输出已截断]'
+/** 用于提取 done marker 的滚动尾部缓冲大小 */
+const MARKER_TAIL_BUFFER = 1024
+
+/** 单次健康检查默认超时 */
+const HEALTH_CHECK_TIMEOUT_MS = 3000
+/** 重启流程总超时（从 preflight 开始计时） */
+const DEFAULT_TOTAL_TIMEOUT_MS = 90_000
+
+export type RestartPhase = 'idle' | 'preflight' | 'executing' | 'waiting' | 'recovered' | 'failed'
+
+export interface RestartResult {
+  ok: boolean
+  phase: RestartPhase
+  reason?: string
+  output: string
+  observedOffline: boolean
+  doneCode: number | null
+}
+
+export interface RestartFlowServer {
+  id: string
+  name: string
+  url: string
+  auth?: { username?: string; password?: string }
+}
+
+export interface RunRestartFlowOptions {
+  server: RestartFlowServer
+  command: string
+  onPhase?: (phase: RestartPhase, detail?: string) => void
+  onOutput?: (text: string) => void
+  isCancelled?: () => boolean
+  totalTimeoutMs?: number
+}
+
+// ============================================
+// 纯函数
+// ============================================
+
+/**
+ * 生成在 PTY 中发送的包装命令：
+ * - 在子 shell 里执行原始命令，保证 stderr 也被捕获
+ * - 用 rc 保存退出码，最后通过 printf 输出 done marker
+ */
+export function buildPtyRestartScript(command: string): string {
+  return `{ ${command}
+rc=$?
+printf '\\n${RESTART_DONE_MARKER}:%s\\n' "$rc"
+} 2>&1`
+}
+
+/**
+ * 从命令输出中提取退出码。
+ * 优先匹配「输出末尾的 marker 行」，否则搜索最后一个 marker 出现位置。
+ * 找不到返回 null。
+ */
+export function extractDoneCode(output: string): number | null {
+  const strict = new RegExp(`\\n${RESTART_DONE_MARKER}:(\\d+)\\s*$`).exec(output)
+  if (strict) return Number(strict[1])
+
+  const lenient = new RegExp(`${RESTART_DONE_MARKER}:(\\d+)`, 'g')
+  let match: RegExpExecArray | null
+  let last: RegExpExecArray | null = null
+  while ((match = lenient.exec(output)) !== null) {
+    last = match
+  }
+  return last ? Number(last[1]) : null
+}
+
+export interface DecideResultInput {
+  recovered: boolean
+  observedOffline: boolean
+  doneCode: number | null
+  timedOut: boolean
+  unauthorized: boolean
+  cancelled: boolean
+}
+
+/**
+ * 纯函数：根据健康轮询与命令执行结果判定最终结论。
+ * 判定顺序（越靠前越「明确」）：
+ *   cancelled > unauthorized > command-failed > 成功(已断开并恢复) > unconfirmed > not-recovered > timeout
+ */
+export function decideResult(input: DecideResultInput): { ok: boolean; reason?: string } {
+  if (input.cancelled) return { ok: false, reason: 'cancelled' }
+  if (input.unauthorized) return { ok: false, reason: 'unauthorized' }
+  if (input.doneCode !== null && input.doneCode !== 0) return { ok: false, reason: 'command-failed' }
+  if (input.recovered && input.observedOffline) return { ok: true }
+  if (input.recovered) return { ok: false, reason: 'unconfirmed' }
+  if (input.observedOffline) return { ok: false, reason: 'not-recovered' }
+  if (input.timedOut) return { ok: false, reason: 'timeout' }
+  return { ok: false, reason: 'timeout' }
+}
+
+// ============================================
+// 健康探测
+// ============================================
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function normalizeConnectionError(err: unknown): string {
+  if (err instanceof DOMException && err.name === 'AbortError') return 'Connection timed out'
+  if (!(err instanceof Error)) return 'Connection failed'
+  return err.message || 'Connection failed'
+}
+
+/**
+ * 获取统一的 fetch 实现（Tauri 桌面端用 plugin-http，浏览器用原生 fetch）。
+ * 与 serverStore.checkHealth 保持一致，但独立实现，避免污染 serverStore 的 healthMap。
+ */
+async function getUnifiedFetch(): Promise<typeof globalThis.fetch> {
+  if (!isTauri()) return globalThis.fetch
+  try {
+    const mod = await import('@tauri-apps/plugin-http')
+    return mod.fetch as unknown as typeof globalThis.fetch
+  } catch {
+    return globalThis.fetch
+  }
+}
+
+/**
+ * 独立健康探测：GET {url}/global/health。
+ * 判定规则与 serverStore.checkHealth 一致：
+ * online = HTTP ok + JSON + healthy === true + version 非空；
+ * 401 → unauthorized；其他非 2xx → error；网络异常/超时 → offline。
+ * 不写入 serverStore 的 healthMap，避免干扰现有健康状态 UI。
+ */
+export async function checkHealthOnce(
+  server: { url: string; auth?: { username?: string; password?: string } },
+  timeoutMs = HEALTH_CHECK_TIMEOUT_MS,
+): Promise<ServerHealth> {
+  const healthUrl = `${server.url}/global/health`
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+  const startTime = Date.now()
+
+  try {
+    const headers: Record<string, string> = {}
+    if (server.auth?.password) {
+      const auth: ServerAuth = { username: server.auth.username || 'opencode', password: server.auth.password }
+      headers['Authorization'] = makeBasicAuthHeader(auth)
+    }
+
+    const f = await getUnifiedFetch()
+    const response = await f(healthUrl, {
+      method: 'GET',
+      signal: controller.signal,
+      headers,
+    })
+
+    const latency = Date.now() - startTime
+
+    if (response.ok) {
+      const contentType = response.headers.get('content-type')?.toLowerCase() ?? ''
+      if (!contentType.includes('application/json')) {
+        return {
+          status: 'error',
+          latency,
+          lastCheck: Date.now(),
+          error: 'Server did not return OpenCode health JSON',
+        }
+      }
+
+      let data: unknown
+      try {
+        data = await response.json()
+      } catch {
+        return { status: 'error', latency, lastCheck: Date.now(), error: 'Invalid OpenCode health JSON' }
+      }
+
+      if (isRecord(data) && data.healthy === true && typeof data.version === 'string' && data.version.trim()) {
+        return { status: 'online', latency, lastCheck: Date.now(), version: data.version }
+      }
+      return { status: 'error', latency, lastCheck: Date.now(), error: 'Not an OpenCode server' }
+    }
+
+    if (response.status === 401) {
+      return { status: 'unauthorized', latency, lastCheck: Date.now(), error: 'Invalid credentials' }
+    }
+    return { status: 'error', latency, lastCheck: Date.now(), error: `HTTP ${response.status}` }
+  } catch (err) {
+    return { status: 'offline', lastCheck: Date.now(), error: normalizeConnectionError(err) }
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+// ============================================
+// PTY 辅助
+// ============================================
+
+interface PtyCommandOptions {
+  ptyId: string
+  script: string
+  onOutput?: (text: string) => void
+  onDoneCode?: (code: number) => void
+  isStopped?: () => boolean
+  timeoutMs?: number
+}
+
+interface PtyCommandResult {
+  output: string
+  doneCode: number | null
+  wsClosed: boolean
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/**
+ * 在指定 PTY 上发送脚本并收集输出。
+ * 结束条件：done marker 出现 / WebSocket 断开（服务被杀）/ 超时 / 被外部停止。
+ * 输出截断上限 32KB（保留头部 + 截断提示），done marker 通过滚动尾部缓冲提取。
+ */
+function runPtyCommand(options: PtyCommandOptions): Promise<PtyCommandResult> {
+  return new Promise(resolve => {
+    const { ptyId, script, onOutput, onDoneCode } = options
+    const timeoutMs = options.timeoutMs ?? 15000
+    const startedAt = Date.now()
+    let output = ''
+    let tailBuffer = ''
+    let truncated = false
+    let doneCode: number | null = null
+    let wsClosed = false
+    let settled = false
+
+    const ws = new WebSocket(getPtyConnectUrl(ptyId))
+    ws.binaryType = 'arraybuffer'
+
+    const appendOutput = (text: string) => {
+      tailBuffer += text
+      if (tailBuffer.length > MARKER_TAIL_BUFFER) {
+        tailBuffer = tailBuffer.slice(-MARKER_TAIL_BUFFER)
+      }
+      if (!truncated) {
+        output += text
+        if (output.length > MAX_OUTPUT_BYTES) {
+          output = output.slice(0, MAX_OUTPUT_BYTES) + TRUNCATED_NOTE
+          truncated = true
+        }
+      }
+      onOutput?.(text)
+    }
+
+    const settle = () => {
+      if (settled) return
+      settled = true
+      clearInterval(checker)
+      try {
+        ws.onopen = null
+        ws.onmessage = null
+        ws.onclose = null
+        ws.onerror = null
+        if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) ws.close()
+      } catch {
+        // ignore
+      }
+      if (doneCode !== null) onDoneCode?.(doneCode)
+      resolve({ output, doneCode, wsClosed })
+    }
+
+    // 兜底：超时或被外部停止时强制结束
+    const checker = setInterval(() => {
+      if (Date.now() - startedAt >= timeoutMs || options.isStopped?.()) settle()
+    }, 200)
+
+    ws.onopen = () => {
+      try {
+        ws.send(script)
+      } catch {
+        settle()
+      }
+    }
+
+    ws.onmessage = event => {
+      const frame = parsePtyFrame(event.data as string | ArrayBuffer)
+      if (!frame || frame.kind === 'control') return
+      appendOutput(frame.data)
+      const code = extractDoneCode(tailBuffer)
+      if (code !== null) {
+        doneCode = code
+        settle()
+      }
+    }
+
+    ws.onclose = () => {
+      wsClosed = true
+      settle()
+    }
+
+    ws.onerror = () => {
+      // onclose 会在 onerror 之后触发，结束逻辑交给 onclose
+    }
+  })
+}
+
+// ============================================
+// 自动识别
+// ============================================
+
+/**
+ * 自动识别 systemd 服务是否可用。
+ * 先做一次健康检查（在线才继续），再通过 PTY 执行探测命令，
+ * 输出包含 'RC:0' 说明 opencode.service 存在且处于 active 状态。
+ */
+export async function detectSystemdActive(
+  server: RestartFlowServer,
+  options?: { onOutput?: (text: string) => void; timeoutMs?: number },
+): Promise<boolean> {
+  const health = await checkHealthOnce(server, HEALTH_CHECK_TIMEOUT_MS)
+  if (health.status !== 'online') return false
+
+  let ptyId: string | null = null
+  try {
+    const pty = await createPtySession({})
+    ptyId = pty.id
+    const probe = 'systemctl is-active --quiet opencode.service 2>/dev/null; echo "RC:$?"'
+    const result = await runPtyCommand({
+      ptyId,
+      script: buildPtyRestartScript(probe),
+      onOutput: options?.onOutput,
+      timeoutMs: options?.timeoutMs ?? 10_000,
+    })
+    return result.output.includes('RC:0')
+  } catch {
+    return false
+  } finally {
+    if (ptyId) void removePtySession(ptyId).catch(() => {})
+  }
+}
+
+// ============================================
+// 重启主流程
+// ============================================
+
+/**
+ * 完整重启流程：
+ * preflight（连续 2 次 online）→ executing（PTY 执行命令）→ waiting（健康轮询等恢复）→ 结果判定。
+ * 轮询与命令执行并发进行；观察到非 online 即记录 observedOffline，连续 2 次 online 视为恢复。
+ * 收尾（finally）：关闭 WebSocket（runPtyCommand 内部完成）、removePtySession、停止轮询。
+ */
+export async function runRestartFlow(options: RunRestartFlowOptions): Promise<RestartResult> {
+  const { server, command, onPhase, onOutput, isCancelled } = options
+  const totalTimeoutMs = options.totalTimeoutMs ?? DEFAULT_TOTAL_TIMEOUT_MS
+  const startedAt = Date.now()
+
+  const cancelled = () => isCancelled?.() === true
+  const deadlineReached = () => Date.now() - startedAt >= totalTimeoutMs
+
+  const state: {
+    doneCode: number | null
+    output: string
+    observedOffline: boolean
+    recovered: boolean
+    unauthorized: boolean
+    timedOut: boolean
+    execDone: boolean
+  } = {
+    doneCode: null,
+    output: '',
+    observedOffline: false,
+    recovered: false,
+    unauthorized: false,
+    timedOut: false,
+    execDone: false,
+  }
+
+  let ptyId: string | null = null
+  let stopPoll = false
+  let finished = false
+
+  const finish = (result: RestartResult): RestartResult => {
+    if (finished) return result
+    finished = true
+    stopPoll = true
+    onPhase?.(result.phase, result.reason)
+    return result
+  }
+
+  const fail = (reason: string, extra?: { output?: string }): RestartResult =>
+    finish({
+      ok: false,
+      phase: 'failed',
+      reason,
+      output: extra?.output ?? state.output,
+      observedOffline: state.observedOffline,
+      doneCode: state.doneCode,
+    })
+
+  try {
+    // ---- preflight：连续 2 次 online ----
+    onPhase?.('preflight')
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      if (cancelled()) return fail('cancelled')
+      if (deadlineReached()) return fail('timeout')
+      const health = await checkHealthOnce(server, HEALTH_CHECK_TIMEOUT_MS)
+      if (health.status === 'unauthorized') return fail('unauthorized')
+      if (health.status !== 'online') return fail('offline')
+      if (attempt === 0) await sleep(300)
+    }
+
+    // ---- executing：创建 PTY 并执行命令 ----
+    onPhase?.('executing')
+    try {
+      const pty = await createPtySession({})
+      ptyId = pty.id
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      return fail('exec-error', { output: `Failed to create PTY session: ${msg}` })
+    }
+
+    const execPromise = runPtyCommand({
+      ptyId,
+      script: buildPtyRestartScript(command),
+      onOutput,
+      onDoneCode: code => {
+        state.doneCode = code
+      },
+      isStopped: () => cancelled() || deadlineReached() || stopPoll,
+      timeoutMs: totalTimeoutMs,
+    }).then(result => {
+      state.doneCode = result.doneCode
+      state.output = result.output
+      state.execDone = true
+      return result
+    })
+
+    // ---- waiting：与 executing 并发开启健康轮询 ----
+    const pollPromise = (async () => {
+      let consecutiveOnline = 0
+      while (!stopPoll) {
+        if (cancelled()) return
+        if (deadlineReached()) {
+          state.timedOut = true
+          return
+        }
+        const health = await checkHealthOnce(server, HEALTH_CHECK_TIMEOUT_MS)
+        if (health.status === 'unauthorized') {
+          state.unauthorized = true
+          return
+        }
+        if (health.status === 'online') {
+          consecutiveOnline += 1
+          // 只有「观察过断开」或「命令已执行完成」后才认可恢复，避免命令未执行完就被判定成功
+          if (consecutiveOnline >= 2 && (state.observedOffline || state.execDone)) {
+            state.recovered = true
+            return
+          }
+        } else {
+          consecutiveOnline = 0
+          if (health.status !== 'checking') state.observedOffline = true
+        }
+        await sleep(500)
+      }
+    })()
+
+    onPhase?.('waiting')
+    await Promise.race([execPromise, pollPromise])
+
+    // 轮询已恢复时让命令执行尽快收敛
+    if (state.recovered) stopPoll = true
+    await execPromise.catch(() => {})
+    stopPoll = true
+    await pollPromise.catch(() => {})
+
+    if (cancelled()) return fail('cancelled')
+    if (state.unauthorized) return fail('unauthorized')
+    state.timedOut = state.timedOut || deadlineReached()
+
+    const decision = decideResult({
+      recovered: state.recovered,
+      observedOffline: state.observedOffline,
+      doneCode: state.doneCode,
+      timedOut: state.timedOut,
+      unauthorized: state.unauthorized,
+      cancelled: false,
+    })
+
+    if (decision.ok) {
+      return finish({
+        ok: true,
+        phase: 'recovered',
+        output: state.output,
+        observedOffline: state.observedOffline,
+        doneCode: state.doneCode,
+      })
+    }
+    return fail(decision.reason ?? 'timeout')
+  } finally {
+    stopPoll = true
+    if (ptyId) {
+      void removePtySession(ptyId).catch(() => {})
+    }
+  }
+}

--- a/src/features/settings/restartServer.ts
+++ b/src/features/settings/restartServer.ts
@@ -69,7 +69,8 @@ export function buildPtyRestartScript(command: string): string {
   return `{ ${command}
 rc=$?
 printf '\\n${RESTART_DONE_MARKER}:%s\\n' "$rc"
-} 2>&1`
+} 2>&1
+`
 }
 
 /**

--- a/src/features/settings/settingsSearchCatalog.ts
+++ b/src/features/settings/settingsSearchCatalog.ts
@@ -28,6 +28,10 @@ const definitions = (tab: SettingsTab, labelKeys: string[]): SettingsSearchDefin
 
 export const SETTINGS_SEARCH_DEFINITIONS: SettingsSearchDefinition[] = [
   ...definitions('servers', ['servers.connections']),
+  {
+    tab: 'servers',
+    labelKey: 'restart.title',
+  },
   ...definitions('models', ['models.visibility']),
   ...definitions('agent', [
     'agent.behavior',

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -65,6 +65,37 @@
     "deleteServer": "Delete Server",
     "deleteServerConfirm": "Remove \"{{name}}\" from the server list? This cannot be undone."
   },
+  "restart": {
+    "title": "Restart Service",
+    "desc": "One-click restart of the OpenCode service on the current server. The UI reconnects automatically after it comes back.",
+    "commandLabel": "Restart command",
+    "commandPlaceholder": "e.g. systemctl restart opencode",
+    "commandHelp": "Leave empty to auto-detect a systemctl service; otherwise fill in the command here.",
+    "warning": "This runs a remote command on the server and may interrupt the service and running sessions. Do not include passwords in the command.",
+    "confirmTitle": "Restart service?",
+    "confirmDesc": "The following command will be executed on server {{name}} ({{url}}):",
+    "confirmText": "Restart",
+    "button": "Restart service",
+    "cancelText": "Cancel restart",
+    "phase": {
+      "preflight": "Checking server status...",
+      "executing": "Executing restart command...",
+      "waiting": "Disconnected, waiting for the service to recover..."
+    },
+    "success": "Restart succeeded. The service is back and the UI has reconnected.",
+    "unconfirmed": "Command finished, but no service restart was observed. Please verify the command.",
+    "commandFailed": "Command failed (exit code {{code}}):",
+    "notRecovered": "The service did not recover in time. You may need to SSH into the server.",
+    "timeout": "Operation timed out; restart outcome unknown.",
+    "unauthorized": "Server authentication failed. Check the credentials.",
+    "offline": "The server is unreachable. Make sure the service is running.",
+    "locked": "Another window is restarting the server. Please wait.",
+    "emptyCommand": "No restart command configured and no systemctl service was detected. Please fill in the command.",
+    "outputLabel": "Command output",
+    "cancel": "Cancel",
+    "cancelled": "Restart cancelled.",
+    "execError": "Could not start command execution on the server. Check the server status."
+  },
   "chat": {
     "pathsFormatting": "Paths & Formatting",
     "pathsFormattingDesc": "How file paths are displayed in messages and tools",

--- a/src/locales/zh-CN/settings.json
+++ b/src/locales/zh-CN/settings.json
@@ -65,6 +65,37 @@
     "deleteServer": "删除服务器",
     "deleteServerConfirm": "确定从列表中移除「{{name}}」？此操作无法撤销。"
   },
+  "restart": {
+    "title": "重启服务",
+    "desc": "一键重启当前服务器上的 OpenCode 服务，重启后界面会自动重连。",
+    "commandLabel": "重启命令",
+    "commandPlaceholder": "例如 systemctl restart opencode",
+    "commandHelp": "留空时点击按钮会自动尝试识别 systemctl 服务；识别不到时请在此填写命令",
+    "warning": "此操作会在服务器上执行远程命令，可能导致服务中断，并会中断正在进行的会话。请勿在命令中包含密码。",
+    "confirmTitle": "确认重启服务？",
+    "confirmDesc": "将在服务器 {{name}}（{{url}}）上执行以下命令：",
+    "confirmText": "确认重启",
+    "button": "重启服务",
+    "cancelText": "取消重启",
+    "phase": {
+      "preflight": "正在检查服务器状态…",
+      "executing": "正在执行重启命令…",
+      "waiting": "已断开，等待服务恢复…"
+    },
+    "success": "重启成功，服务已恢复，界面已自动重连。",
+    "unconfirmed": "命令执行完成，但未观察到服务重启，请确认命令是否正确。",
+    "commandFailed": "命令执行失败（退出码 {{code}}）：",
+    "notRecovered": "服务未在时限内恢复，可能需要 SSH 到服务器检查。",
+    "timeout": "操作超时，未确认是否重启成功。",
+    "unauthorized": "服务器认证失败，请检查账号密码。",
+    "offline": "服务器当前不可达，请先确认服务运行正常。",
+    "locked": "另一个窗口正在进行重启，请稍候。",
+    "emptyCommand": "未填写重启命令，且自动识别未找到可用的 systemctl 服务。请填写重启命令。",
+    "outputLabel": "命令输出",
+    "cancel": "取消",
+    "cancelled": "已取消重启。",
+    "execError": "无法在服务器上启动命令执行，请检查服务器状态。"
+  },
   "chat": {
     "pathsFormatting": "路径和格式",
     "pathsFormattingDesc": "消息和工具中文件路径的显示方式",


### PR DESCRIPTION
## 功能说明

在「服务器」设置页签新增「重启服务」卡片，用户可在界面一键重启远程 OpenCode 服务，全程无需 SSH：

- **自定义重启命令**：按服务器分别记忆（per-server localStorage），适配 Docker / systemd / 直接进程等不同部署方式
- **自动识别**：命令留空时自动检测 systemctl 服务（`systemctl is-active --quiet opencode.service`），识别不到则提示填写
- **安全确认**：执行前确认框展示目标服务器与完整命令原文 + 危险操作警告
- **全程验证**：通过 PTY 在服务端执行命令，健康检查（`/global/health`）盯梢「断开→恢复」：连续 2 次在线判定恢复，90 秒总超时
- **明确结果**：成功 / 命令执行失败（带退出码）/ 未观察到重启（命令可能未生效）/ 服务未恢复（提示 SSH 检查）/ 认证失败 / 超时，失败时展示命令输出（纯文本、32KB 截断）
- **健壮性**：并发锁防多窗口同时重启、支持执行中取消、服务恢复后主动触发 SSE 重连、PTY 会话用完清理

## 验证

- `npm run validate` 全绿：typecheck + eslint + vitest（599 个测试，含新增 18 个）+ 生产构建
- 核心判定逻辑（退出码提取、结果状态机、健康探测）均有单测覆盖

## 残余风险

- PTY/WebSocket 集成路径依赖真实服务端环境，未在 CI 中覆盖
- 自动识别仅支持 systemd 单一场景，其他部署方式需用户填写命令
- 服务快速重启（重启间隔 < 500ms 轮询间隔）时可能采样不到断开，会按「未观察到重启」提示，不会误报成功