### PR TITLE
feat: render tool attachments inline and add save/copy actions

### DIFF
--- a/src/features/attachment/AttachmentItem.test.tsx
+++ b/src/features/attachment/AttachmentItem.test.tsx
@@ -107,6 +107,41 @@ describe('AttachmentItem defaultExpanded', () => {
     expect(screen.queryByTitle('attachment.saveToFile')).toBeNull()
   })
 
+  it('does not show a download button for a file:// url without content', () => {
+    const fileUrlAttachment: Attachment = {
+      id: 'a5',
+      type: 'file',
+      displayName: 'local.txt',
+      url: 'file:///home/user/local.txt',
+      mime: 'text/plain',
+      category: 'user',
+    }
+    render(
+      <FullscreenProvider>
+        <AttachmentItem attachment={fileUrlAttachment} />
+      </FullscreenProvider>,
+    )
+    expect(screen.queryByTitle('attachment.saveToFile')).toBeNull()
+  })
+
+  it('shows a download button for a file:// url when content exists', () => {
+    const fileUrlWithContentAttachment: Attachment = {
+      id: 'a6',
+      type: 'file',
+      displayName: 'local.txt',
+      url: 'file:///home/user/local.txt',
+      content: 'hello world',
+      mime: 'text/plain',
+      category: 'user',
+    }
+    render(
+      <FullscreenProvider>
+        <AttachmentItem attachment={fileUrlWithContentAttachment} />
+      </FullscreenProvider>,
+    )
+    expect(screen.getByTitle('attachment.saveToFile')).toBeTruthy()
+  })
+
   it('shows copied state only when copy succeeds', async () => {
     vi.mocked(copyTextToClipboard).mockResolvedValue(undefined)
     render(

--- a/src/features/attachment/AttachmentItem.test.tsx
+++ b/src/features/attachment/AttachmentItem.test.tsx
@@ -1,0 +1,94 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AttachmentItem } from './AttachmentItem'
+import type { Attachment } from './types'
+import { FullscreenProvider } from '../../contexts'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}))
+
+const imgAttachment: Attachment = {
+  id: 'a1',
+  type: 'file',
+  displayName: 'test.png',
+  url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  mime: 'image/png',
+  category: 'user',
+}
+
+const txtAttachment: Attachment = {
+  id: 'a2',
+  type: 'file',
+  displayName: 'notes.txt',
+  url: 'data:text/plain;charset=utf-8,hello%20world',
+  mime: 'text/plain',
+  category: 'user',
+}
+
+const noUrlAttachment: Attachment = {
+  id: 'a3',
+  type: 'file',
+  displayName: 'notes.txt',
+  mime: 'text/plain',
+  category: 'user',
+}
+
+describe('AttachmentItem defaultExpanded', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(cb =>
+      window.setTimeout(() => cb(performance.now()), 0),
+    )
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(id => {
+      clearTimeout(id)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('renders image body immediately when defaultExpanded is true', () => {
+    render(
+      <FullscreenProvider>
+        <AttachmentItem attachment={imgAttachment} expandable defaultExpanded />
+      </FullscreenProvider>,
+    )
+    act(() => {
+      vi.runAllTimers()
+    })
+    expect(screen.getByAltText('test.png')).toBeTruthy()
+  })
+
+  it('does not render image body when collapsed', () => {
+    render(
+      <FullscreenProvider>
+        <AttachmentItem attachment={imgAttachment} expandable />
+      </FullscreenProvider>,
+    )
+    act(() => {
+      vi.runAllTimers()
+    })
+    expect(screen.queryByAltText('test.png')).toBeNull()
+  })
+
+  it('shows a download button in the header when the file has a url', () => {
+    render(
+      <FullscreenProvider>
+        <AttachmentItem attachment={txtAttachment} />
+      </FullscreenProvider>,
+    )
+    expect(screen.getByTitle('attachment.saveToFile')).toBeTruthy()
+  })
+
+  it('does not show a download button when there is no url or content', () => {
+    render(
+      <FullscreenProvider>
+        <AttachmentItem attachment={noUrlAttachment} />
+      </FullscreenProvider>,
+    )
+    expect(screen.queryByTitle('attachment.saveToFile')).toBeNull()
+  })
+})

--- a/src/features/attachment/AttachmentItem.test.tsx
+++ b/src/features/attachment/AttachmentItem.test.tsx
@@ -3,10 +3,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AttachmentItem } from './AttachmentItem'
 import type { Attachment } from './types'
 import { FullscreenProvider } from '../../contexts'
+import { copyTextToClipboard } from '../../utils'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (k: string) => k }),
 }))
+
+vi.mock('../../utils', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils')>()
+  return { ...actual, copyTextToClipboard: vi.fn(), clipboardErrorHandler: vi.fn() }
+})
 
 const imgAttachment: Attachment = {
   id: 'a1',
@@ -30,6 +36,15 @@ const noUrlAttachment: Attachment = {
   id: 'a3',
   type: 'file',
   displayName: 'notes.txt',
+  mime: 'text/plain',
+  category: 'user',
+}
+
+const contentAttachment: Attachment = {
+  id: 'a4',
+  type: 'file',
+  displayName: 'notes.txt',
+  content: 'hello world',
   mime: 'text/plain',
   category: 'user',
 }
@@ -90,5 +105,37 @@ describe('AttachmentItem defaultExpanded', () => {
       </FullscreenProvider>,
     )
     expect(screen.queryByTitle('attachment.saveToFile')).toBeNull()
+  })
+
+  it('shows copied state only when copy succeeds', async () => {
+    vi.mocked(copyTextToClipboard).mockResolvedValue(undefined)
+    render(
+      <FullscreenProvider>
+        <AttachmentItem attachment={contentAttachment} expandable defaultExpanded />
+      </FullscreenProvider>,
+    )
+    act(() => {
+      vi.runAllTimers()
+    })
+    await act(async () => {
+      screen.getByTitle('attachment.copyContent').click()
+    })
+    expect(screen.getByText('common:copied')).toBeTruthy()
+  })
+
+  it('does not show copied state when copy fails', async () => {
+    vi.mocked(copyTextToClipboard).mockRejectedValue(new Error('clipboard denied'))
+    render(
+      <FullscreenProvider>
+        <AttachmentItem attachment={contentAttachment} expandable defaultExpanded />
+      </FullscreenProvider>,
+    )
+    act(() => {
+      vi.runAllTimers()
+    })
+    await act(async () => {
+      screen.getByTitle('attachment.copyContent').click()
+    })
+    expect(screen.queryByText('common:copied')).toBeNull()
   })
 })

--- a/src/features/attachment/AttachmentItem.tsx
+++ b/src/features/attachment/AttachmentItem.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect, memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { CloseIcon, ChevronDownIcon, CopyIcon, CheckIcon, DownloadIcon, ExpandIcon } from '../../components/Icons'
-import { getAttachmentIcon, hasExpandableContent } from './utils'
+import { getAttachmentIcon, hasExpandableContent, canDownload } from './utils'
 import { getMaterialIconUrl } from '../../utils/materialIcons'
 import { useDelayedRender } from '../../hooks/useDelayedRender'
 import { AttachmentDetailModal } from './AttachmentDetailModal'
@@ -34,8 +34,8 @@ function AttachmentItemComponent({
 
   const { Icon, colorClass } = getAttachmentIcon(attachment)
   const canExpand = expandable && hasExpandableContent(attachment)
-  // 可下载：有 url 或文本 content（下载按钮常驻 header，展开与否都能保存文件）
-  const hasDownloadable = !!attachment.url || !!attachment.content
+  // 可下载：有 content 或 data:/http(s) url（下载按钮常驻 header，展开与否都能保存文件）
+  const hasDownloadable = canDownload(attachment)
 
   const handleDownload = useCallback(
     (e: React.MouseEvent) => {
@@ -43,14 +43,18 @@ function AttachmentItemComponent({
       const isImage = attachment.mime?.startsWith('image/')
       const fileName = attachment.displayName || (isImage ? 'image' : 'attachment.txt')
 
+      // file:// 无法在浏览器/WebView 中 fetch，仅能保存文本 content
+      if (attachment.content) {
+        saveData(new TextEncoder().encode(attachment.content), fileName, 'text/plain;charset=utf-8')
+        return
+      }
+
       if (isImage && attachment.url) {
         // 图片：从 data URI 或 URL fetch 后保存
         fetch(attachment.url)
           .then(res => res.arrayBuffer())
           .then(buf => saveData(new Uint8Array(buf), fileName, attachment.mime || 'image/png'))
           .catch(err => console.warn('[AttachmentItem] save image failed:', err))
-      } else if (attachment.content) {
-        saveData(new TextEncoder().encode(attachment.content), fileName, 'text/plain;charset=utf-8')
       } else if (attachment.url) {
         // 非图片但有 url（如 base64 文本/二进制）：fetch 后保存
         fetch(attachment.url)
@@ -232,7 +236,7 @@ function ExpandedContent({
   const { type, url, content, relativePath, mime, agentName, agentDescription } = attachment
   const isImage = mime?.startsWith('image/')
   const hasContent = !!content
-  const hasDownloadable = hasContent || !!url
+  const hasDownloadable = canDownload(attachment)
 
   // Content Area
   let contentNode = null

--- a/src/features/attachment/AttachmentItem.tsx
+++ b/src/features/attachment/AttachmentItem.tsx
@@ -189,13 +189,6 @@ function AttachmentItemComponent({
   )
 }
 
-interface ExpandedContentProps {
-  attachment: Attachment
-  imageError: boolean
-  onImageError: () => void
-  onOpenDetail: () => void
-}
-
 function MetaRow({
   label,
   value,

--- a/src/features/attachment/AttachmentItem.tsx
+++ b/src/features/attachment/AttachmentItem.tsx
@@ -66,7 +66,12 @@ function AttachmentItemComponent({
     async (e: React.MouseEvent) => {
       e.stopPropagation()
       if (!attachment.content) return
-      await copyTextToClipboard(attachment.content).catch(err => clipboardErrorHandler('copy', err))
+      try {
+        await copyTextToClipboard(attachment.content)
+      } catch (err) {
+        clipboardErrorHandler('copy', err)
+        throw err
+      }
     },
     [attachment.content],
   )
@@ -371,7 +376,11 @@ function ActionBar({
   const handleCopy = useCallback(
     async (e: React.MouseEvent) => {
       e.stopPropagation()
-      await onCopy(e)
+      try {
+        await onCopy(e)
+      } catch {
+        return
+      }
       setCopied(true)
       if (timeoutRef.current) clearTimeout(timeoutRef.current)
       timeoutRef.current = setTimeout(() => setCopied(false), 2000)

--- a/src/features/attachment/AttachmentItem.tsx
+++ b/src/features/attachment/AttachmentItem.tsx
@@ -14,6 +14,7 @@ interface AttachmentItemProps {
   onRemove?: (id: string) => void
   size?: 'sm' | 'md'
   expandable?: boolean
+  defaultExpanded?: boolean
   className?: string
 }
 
@@ -22,16 +23,53 @@ function AttachmentItemComponent({
   onRemove,
   size = 'md',
   expandable = false,
+  defaultExpanded = false,
   className,
 }: AttachmentItemProps) {
   const { t } = useTranslation(['commands', 'common'])
-  const [isExpanded, setIsExpanded] = useState(false)
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded)
   const [imageError, setImageError] = useState(false)
   const [isModalOpen, setIsModalOpen] = useState(false)
   const shouldRenderBody = useDelayedRender(isExpanded)
 
   const { Icon, colorClass } = getAttachmentIcon(attachment)
   const canExpand = expandable && hasExpandableContent(attachment)
+  // 可下载：有 url 或文本 content（下载按钮常驻 header，展开与否都能保存文件）
+  const hasDownloadable = !!attachment.url || !!attachment.content
+
+  const handleDownload = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      const isImage = attachment.mime?.startsWith('image/')
+      const fileName = attachment.displayName || (isImage ? 'image' : 'attachment.txt')
+
+      if (isImage && attachment.url) {
+        // 图片：从 data URI 或 URL fetch 后保存
+        fetch(attachment.url)
+          .then(res => res.arrayBuffer())
+          .then(buf => saveData(new Uint8Array(buf), fileName, attachment.mime || 'image/png'))
+          .catch(err => console.warn('[AttachmentItem] save image failed:', err))
+      } else if (attachment.content) {
+        saveData(new TextEncoder().encode(attachment.content), fileName, 'text/plain;charset=utf-8')
+      } else if (attachment.url) {
+        // 非图片但有 url（如 base64 文本/二进制）：fetch 后保存
+        fetch(attachment.url)
+          .then(res => res.arrayBuffer())
+          .then(buf => saveData(new Uint8Array(buf), fileName, attachment.mime || 'application/octet-stream'))
+          .catch(err => console.warn('[AttachmentItem] save file failed:', err))
+      }
+    },
+    [attachment],
+  )
+
+  const handleCopy = useCallback(
+    async (e: React.MouseEvent) => {
+      e.stopPropagation()
+      if (!attachment.content) return
+      await copyTextToClipboard(attachment.content).catch(err => clipboardErrorHandler('copy', err))
+    },
+    [attachment.content],
+  )
 
   // file/folder 使用 material icon，其他类型用通用 SVG 图标
   const useMaterialIcon = attachment.type === 'file' || attachment.type === 'folder'
@@ -88,6 +126,17 @@ function AttachmentItemComponent({
         <span className="text-text-200 flex-1 min-w-0 truncate text-left" title={attachment.displayName}>
           {attachment.displayName}
         </span>
+        {hasDownloadable && (
+          <button
+            onClick={handleDownload}
+            className="inline-flex items-center gap-0.5 shrink-0 rounded px-1 py-0.5 text-[length:var(--fs-xxs)] text-accent-main-100 hover:text-accent-main-50 hover:bg-accent-main-100/10 transition-colors"
+            title={t('attachment.saveToFile')}
+            aria-label={t('attachment.saveToFile')}
+          >
+            <DownloadIcon size={11} />
+            <span className="hidden md:inline">{t('common:save')}</span>
+          </button>
+        )}
         {canExpand && (
           <span className={`text-text-400 transition-transform duration-300 ${isExpanded ? '' : '-rotate-90'}`}>
             <ChevronDownIcon size={10} />
@@ -121,6 +170,8 @@ function AttachmentItemComponent({
                 imageError={imageError}
                 onImageError={() => setImageError(true)}
                 onOpenDetail={() => setIsModalOpen(true)}
+                onCopy={handleCopy}
+                onDownload={handleDownload}
               />
             )}
           </div>
@@ -162,12 +213,28 @@ function MetaRow({
   )
 }
 
-function ExpandedContent({ attachment, imageError, onImageError, onOpenDetail }: ExpandedContentProps) {
+interface ExpandedContentProps {
+  attachment: Attachment
+  imageError: boolean
+  onImageError: () => void
+  onOpenDetail: () => void
+  onCopy: (e: React.MouseEvent) => Promise<void> | void
+  onDownload: (e: React.MouseEvent) => void
+}
+
+function ExpandedContent({
+  attachment,
+  imageError,
+  onImageError,
+  onOpenDetail,
+  onCopy,
+  onDownload,
+}: ExpandedContentProps) {
   const { t } = useTranslation(['commands', 'common'])
   const { type, url, content, relativePath, mime, agentName, agentDescription } = attachment
   const isImage = mime?.startsWith('image/')
   const hasContent = !!content
-  const hasDownloadable = hasContent || (!!isImage && !!url)
+  const hasDownloadable = hasContent || !!url
 
   // Content Area
   let contentNode = null
@@ -200,10 +267,11 @@ function ExpandedContent({ attachment, imageError, onImageError, onOpenDetail }:
 
       {/* 操作按钮栏 */}
       <ActionBar
-        attachment={attachment}
         hasContent={hasContent}
         hasDownloadable={hasDownloadable}
         onOpenDetail={onOpenDetail}
+        onCopy={onCopy}
+        onDownload={onDownload}
         showBorderTop={!!contentNode}
       />
 
@@ -274,14 +342,22 @@ function ExpandedContent({ attachment, imageError, onImageError, onOpenDetail }:
 // ============================================
 
 interface ActionBarProps {
-  attachment: Attachment
   hasContent: boolean
   hasDownloadable: boolean
   onOpenDetail: () => void
+  onCopy: (e: React.MouseEvent) => Promise<void> | void
+  onDownload: (e: React.MouseEvent) => void
   showBorderTop: boolean
 }
 
-function ActionBar({ attachment, hasContent, hasDownloadable, onOpenDetail, showBorderTop }: ActionBarProps) {
+function ActionBar({
+  hasContent,
+  hasDownloadable,
+  onOpenDetail,
+  onCopy,
+  onDownload,
+  showBorderTop,
+}: ActionBarProps) {
   const { t } = useTranslation(['commands', 'common'])
   const [copied, setCopied] = useState(false)
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -295,36 +371,12 @@ function ActionBar({ attachment, hasContent, hasDownloadable, onOpenDetail, show
   const handleCopy = useCallback(
     async (e: React.MouseEvent) => {
       e.stopPropagation()
-      if (!attachment.content) return
-      try {
-        await copyTextToClipboard(attachment.content)
-        setCopied(true)
-        if (timeoutRef.current) clearTimeout(timeoutRef.current)
-        timeoutRef.current = setTimeout(() => setCopied(false), 2000)
-      } catch (err) {
-        clipboardErrorHandler('copy', err)
-      }
+      await onCopy(e)
+      setCopied(true)
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+      timeoutRef.current = setTimeout(() => setCopied(false), 2000)
     },
-    [attachment.content],
-  )
-
-  const handleDownload = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation()
-      const isImage = attachment.mime?.startsWith('image/')
-      const fileName = attachment.displayName || (isImage ? 'image' : 'attachment.txt')
-
-      if (isImage && attachment.url) {
-        // 图片：从 data URI 或 URL fetch 后保存
-        fetch(attachment.url)
-          .then(res => res.arrayBuffer())
-          .then(buf => saveData(new Uint8Array(buf), fileName, attachment.mime || 'image/png'))
-          .catch(err => console.warn('[AttachmentItem] save image failed:', err))
-      } else if (attachment.content) {
-        saveData(new TextEncoder().encode(attachment.content), fileName, 'text/plain;charset=utf-8')
-      }
-    },
-    [attachment],
+    [onCopy],
   )
 
   const handleOpenDetail = useCallback(
@@ -365,7 +417,7 @@ function ActionBar({ attachment, hasContent, hasDownloadable, onOpenDetail, show
 
       {hasDownloadable && (
         <button
-          onClick={handleDownload}
+          onClick={onDownload}
           className={`${btnBase} text-text-400 hover:text-text-200 hover:bg-bg-300/50`}
           title={t('attachment.saveToFile')}
         >

--- a/src/features/attachment/utils.ts
+++ b/src/features/attachment/utils.ts
@@ -104,12 +104,10 @@ export function getMentionText(attachment: Attachment): string {
  * 判断附件是否有可展开的内容
  */
 export function hasExpandableContent(attachment: Attachment): boolean {
-  const isImage = attachment.mime?.startsWith('image/')
-
   switch (attachment.type) {
     case 'file':
-      // 图片需要 url，其他文件需要 content 或 relativePath
-      return isImage ? !!attachment.url : !!attachment.content || !!attachment.relativePath
+      // 图片需要 url，其他文件需要 content / relativePath / url（均可用于下载或查看）
+      return !!attachment.url || !!attachment.content || !!attachment.relativePath
     case 'folder':
       return !!attachment.relativePath
     case 'agent':

--- a/src/features/attachment/utils.ts
+++ b/src/features/attachment/utils.ts
@@ -106,7 +106,7 @@ export function getMentionText(attachment: Attachment): string {
 export function hasExpandableContent(attachment: Attachment): boolean {
   switch (attachment.type) {
     case 'file':
-      // 图片需要 url，其他文件需要 content / relativePath / url（均可用于下载或查看）
+      // 有 url（用于展示/下载）或 content（文本预览）或 relativePath（定位）即可展开
       return !!attachment.url || !!attachment.content || !!attachment.relativePath
     case 'folder':
       return !!attachment.relativePath
@@ -117,6 +117,16 @@ export function hasExpandableContent(attachment: Attachment): boolean {
     default:
       return false
   }
+}
+
+/**
+ * 判断附件是否可下载保存
+ * 仅 content 文本、data:/http(s) url 可直接获取数据；file:// 在浏览器/WebView 中无法 fetch，视为不可下载
+ */
+export function canDownload(attachment: Attachment): boolean {
+  if (attachment.content) return true
+  if (!attachment.url) return false
+  return !attachment.url.startsWith('file://')
 }
 
 export function getAttachmentIcon(attachment: Attachment): { Icon: React.FC; colorClass: string } {

--- a/src/features/message/MessageRenderer.tsx
+++ b/src/features/message/MessageRenderer.tsx
@@ -981,6 +981,8 @@ const ToolGroup = memo(function ToolGroup({
   const totalCount = parts.length
   const isAllDone = doneCount === totalCount
   const hasActiveTools = parts.some(isToolPartActive)
+  // 工具组内是否有需要直接展示的附件（attach_file 等）：有则必须展开
+  const hasAttachments = parts.some(p => (p.state.attachments ?? []).length > 0)
   const stepsSummary = descriptiveToolSteps ? buildDescriptiveToolStepsSummary(parts, t) : undefined
 
   // 汇总所有成功完成的工具的 diff stats（失败的不算）
@@ -1002,13 +1004,14 @@ const ToolGroup = memo(function ToolGroup({
 
   // 沉浸模式下：判断工具组是否包含需要用户阅读的工具
   const hasReadableTools = immersiveMode && parts.some(p => isReadableTool(p.tool))
-  // 过程折叠：steps 默认收起，只有权限/提问才自动展开
-  // 其它模式：活跃/流式/可读工具时展开
+  // 过程折叠：steps 默认收起，只有权限/提问/附件才自动展开
+  // 其它模式：活跃/流式/可读工具/附件时展开
   const shouldStartExpanded = processCollapseEnabled
-    ? !!hasPendingInteraction
+    ? !!hasPendingInteraction || hasAttachments
     : !descriptiveToolSteps ||
       hasActiveTools ||
       hasPendingInteraction ||
+      hasAttachments ||
       (immersiveMode && !!isStreaming && hasReadableTools)
 
   const groupStateKey = `message:${parts[0]?.messageID || 'unknown'}:tool-group:${parts[0]?.id || 'empty'}`
@@ -1020,6 +1023,12 @@ const ToolGroup = memo(function ToolGroup({
     useDisclosureScrollLock()
 
   useEffect(() => {
+    // 附件：无论何种模式都强制展开，保证图片/文件直接可见
+    if (hasAttachments) {
+      setExpanded(true, { touched: false, respectUser: true })
+      return
+    }
+
     if (!descriptiveToolSteps) return
 
     // 权限/提问：必须展开让用户操作
@@ -1053,6 +1062,7 @@ const ToolGroup = memo(function ToolGroup({
     processCollapseEnabled,
     hasActiveTools,
     hasPendingInteraction,
+    hasAttachments,
     immersiveMode,
     hasReadableTools,
     isStreaming,

--- a/src/features/message/parts/AttachmentPartViews.tsx
+++ b/src/features/message/parts/AttachmentPartViews.tsx
@@ -8,13 +8,14 @@ import type { FilePart, AgentPart, TextPart } from '../../../types/message'
 
 interface FilePartViewProps {
   part: FilePart
+  defaultExpanded?: boolean
 }
 
-export const FilePartView = memo(function FilePartView({ part }: FilePartViewProps) {
+export const FilePartView = memo(function FilePartView({ part, defaultExpanded = false }: FilePartViewProps) {
   // 转换为 Attachment 类型
   const attachment = fromFilePart(part)
 
-  return <AttachmentItem attachment={attachment} expandable size="sm" />
+  return <AttachmentItem attachment={attachment} expandable size="sm" defaultExpanded={defaultExpanded} />
 })
 
 // ============================================

--- a/src/features/message/parts/ToolPartView.test.tsx
+++ b/src/features/message/parts/ToolPartView.test.tsx
@@ -77,6 +77,14 @@ vi.mock('../tools', () => ({
   hasTodos: () => false,
 }))
 
+vi.mock('./AttachmentPartViews', () => ({
+  FilePartView: ({ part, defaultExpanded }: { part: { filename?: string }; defaultExpanded?: boolean }) => (
+    <span data-testid="file-part-view">
+      file:{part.filename}:{String(!!defaultExpanded)}
+    </span>
+  ),
+}))
+
 function createRunningToolPart(): ToolPart {
   return {
     id: 'tool-1',
@@ -89,6 +97,33 @@ function createRunningToolPart(): ToolPart {
       status: 'running',
       title: 'npm run build',
       time: { start: 7_500 },
+    },
+  }
+}
+
+function createAttachedToolPart(): ToolPart {
+  return {
+    id: 'tool-2',
+    sessionID: 'session-1',
+    messageID: 'message-1',
+    type: 'tool',
+    callID: 'call-2',
+    tool: 'attach_file',
+    state: {
+      status: 'completed',
+      title: 'Attach File',
+      time: { start: 7_500 },
+      attachments: [
+        {
+          id: 'att-1',
+          sessionID: 'session-1',
+          messageID: 'message-1',
+          type: 'file',
+          filename: 'image.png',
+          url: 'data:image/png;base64,iVBORw0KGgo=',
+          mime: 'image/png',
+        },
+      ],
     },
   }
 }
@@ -150,5 +185,15 @@ describe('ToolPartView running duration', () => {
 
     rerender(<ToolPartView part={part} descriptive />)
     expect(container.firstElementChild?.className).toContain('pt-1')
+  })
+
+  it('renders state.attachments via FilePartView with defaultExpanded', () => {
+    render(<ToolPartView part={createAttachedToolPart()} />)
+    expect(screen.getByTestId('file-part-view')).toHaveTextContent('file:image.png:true')
+  })
+
+  it('does not render attachments when state has none', () => {
+    render(<ToolPartView part={createRunningToolPart()} />)
+    expect(screen.queryByTestId('file-part-view')).toBeNull()
   })
 })

--- a/src/features/message/parts/ToolPartView.tsx
+++ b/src/features/message/parts/ToolPartView.tsx
@@ -25,6 +25,7 @@ import {
   TaskRenderer,
   hasTodos,
 } from '../tools'
+import { FilePartView } from './AttachmentPartViews'
 import { MSG_SPACING } from '../messageSpacing'
 import { MessageExpandPanel, useMessageExpandRender } from '../messageExpand'
 
@@ -118,10 +119,12 @@ export const ToolPartView = memo(function ToolPartView({
   const permissionContentHidden =
     compactInlinePermission && !isEditWritePermission && !isTaskTool && !!permissionRequest
   const isReadable = isReadableTool(toolName)
+  const hasAttachments = (state.attachments ?? []).length > 0
   const shouldStartExpanded =
     isActive ||
     hasPendingInteraction ||
     permissionResolved ||
+    hasAttachments ||
     (immersiveMode && descriptive && isStreaming && isReadable)
 
   const [expanded, setExpanded] = useUiDisclosureState(`message:${part.messageID}:tool:${part.id}`, shouldStartExpanded)
@@ -148,6 +151,10 @@ export const ToolPartView = memo(function ToolPartView({
       frameId = requestAnimationFrame(() => {
         setExpanded(true, { touched: false, respectUser: true })
       })
+    } else if (hasAttachments) {
+      frameId = requestAnimationFrame(() => {
+        setExpanded(true, { touched: false, respectUser: true })
+      })
     } else if (immersiveMode && descriptive && !isReadable) {
       frameId = requestAnimationFrame(() => {
         setExpanded(false, { touched: false, respectUser: true })
@@ -166,6 +173,7 @@ export const ToolPartView = memo(function ToolPartView({
     isActive,
     hasPendingInteraction,
     permissionResolved,
+    hasAttachments,
     immersiveMode,
     descriptive,
     isStreaming,
@@ -197,10 +205,19 @@ export const ToolPartView = memo(function ToolPartView({
     setIsChildFullscreen(isFullscreen)
   }, [])
 
+  const attachments = state.attachments ?? []
+
   const bodyContent = (
     <>
       {!hideToolBodyForPermission && (
         <ToolBody part={part} data={toolData} onFullscreenChange={handleFullscreenChange} />
+      )}
+      {attachments.length > 0 && (
+        <div className="mt-1 flex flex-wrap gap-1.5 px-1 pb-1">
+          {attachments.map(attachmentPart => (
+            <FilePartView key={attachmentPart.id} part={attachmentPart} defaultExpanded />
+          ))}
+        </div>
       )}
       {displayPermission && (
         <div className={hideToolBodyForPermission && !permissionContentHidden ? '' : MSG_SPACING.inner}>


### PR DESCRIPTION
## Summary

When a tool (e.g. `attach_file`) emits `state.attachments`, the UI previously did not show them. This PR renders those attachments inline in the tool part and makes them visible with zero clicks.

## Changes

- `ToolPartView`: renders `state.attachments` via `FilePartView` with `defaultExpanded`, and auto-expands the tool when attachments exist.
- `MessageRenderer`/`ToolGroup`: forces the tool group to expand when any part has attachments (including in process-collapse mode) so images/files are directly visible.
- `AttachmentItem`: adds a persistent Save/download button in the header (works for image, text and binary), and lifts copy/download handlers to the component level for reuse in both the header and the expanded action bar.
- `AttachmentPartViews`: `FilePartView` accepts a `defaultExpanded` prop.
- `utils.hasExpandableContent`: relaxes the `file` case to `url || content || relativePath` so non-image files with a `url` can expand.
- Tests: `ToolPartView` renders attachments with `defaultExpanded` and omits them when none; `AttachmentItem` verifies `defaultExpanded` and the header download button.

## Result

Zero-click: images render inline (~60-70% width), and file cards show a Save button in the header plus Detail/Save in the expanded panel.