### PR TITLE
fix: repair the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,11 +384,11 @@ docker/                  # Docker 配置（Gateway / Frontend / Backend）
 
 ## Star History
 
-<a href="https://www.star-history.com/#lehhair/OpenCodeUI&Date">
+<a href="https://star-history.dera.page/#lehhair/OpenCodeUI&type=Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=lehhair/OpenCodeUI&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=lehhair/OpenCodeUI&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=lehhair/OpenCodeUI&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=lehhair/OpenCodeUI&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=lehhair/OpenCodeUI&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=lehhair/OpenCodeUI&type=Date" />
  </picture>
 </a>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -333,11 +333,11 @@ Some UI styles are inspired by the [Claude](https://claude.ai) interface design.
 
 ## Star History
 
-<a href="https://www.star-history.com/#lehhair/OpenCodeUI&Date">
+<a href="https://star-history.dera.page/#lehhair/OpenCodeUI&type=Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=lehhair/OpenCodeUI&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=lehhair/OpenCodeUI&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=lehhair/OpenCodeUI&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=lehhair/OpenCodeUI&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=lehhair/OpenCodeUI&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=lehhair/OpenCodeUI&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart on the project page currently fails to render because the upstream API it depended on is broken. This PR updates the chart image and link in both README.md and README_EN.md to use a working mirror of the star history service, so the chart displays correctly again.